### PR TITLE
[page-manager.js] Look through intermediate nodes for pageOnClick data.

### DIFF
--- a/assets/js/page-manager.js
+++ b/assets/js/page-manager.js
@@ -252,16 +252,15 @@ class PageManager {
             return;
         }
 
-        if (!event.target.dataset.pageOnClick) {
-            return;
+        for (var t = event.target; t && t != event.currentTarget; t = t.parentNode) {
+            if (t.dataset.pageOnClick) {
+                event.preventDefault();
+                const requestedPageId = t.dataset.pageOnClick;
+                const data = this._extractPageDataArgs(t);
+                this.loadPage(requestedPageId, data);
+                break;
+            }
         }
-
-        event.preventDefault();
-
-        const requestedPageId = event.target.dataset.pageOnClick;
-        const data = this._extractPageDataArgs(event.target);
-
-        this.loadPage(requestedPageId, data);
     }
 
     async _handleElementMouseover(event) {


### PR DESCRIPTION
Currently, an onClick event only considers the clicked-on target's `data-page-on-click` data, and fails to consider similar data on DOM elements intermediate between the target and the event-handling node (i.e. "body"). This in turn means that `data-page-on-click` cannot be applied to container elements, as is currently the case for the home page link.

The change makes it so that all nodes, starting at the clicked-on node, and up to the handling node, are checked for whether they define `data-page-on-click`, and the first such available datum (in bubble order) is used to navigate to the new page.