### PR TITLE
Damage Calculator Functionality

### DIFF
--- a/assets/css/pages/damage-calculator-page.css
+++ b/assets/css/pages/damage-calculator-page.css
@@ -1,0 +1,245 @@
+.damage-calculator-section-content {
+    display: flex;
+    flex-flow: column nowrap;
+
+    padding: 13px 20px 30px 20px;
+    height: 100%;
+    overflow: hidden;
+}
+
+.damage-calculator-content {
+    flex-shrink: 1;
+    min-height: 0;
+    overflow-y: hidden;
+}
+
+#damage-simulation-content > form {
+    height: 100%;
+    display: flex;
+    flex-flow: column;
+}
+
+#damage-form-editor {
+    flex-shrink: 1;
+    overflow-y: auto;
+    padding: 4px;
+}
+
+#damage-calculation-content {
+    overflow-y: auto;
+    gap: 1rem;
+    display: flex;
+    flex-flow: column nowrap;
+}
+
+#damage-calculation-content > table input {
+    width: 100%;
+}
+
+#damage-calculator-options {
+    margin-bottom: 30px;
+    justify-content: center;
+}
+
+.damage-cat-form {
+    border: 1px solid var(--color-subtle);
+    border-top-left-radius: 30px;
+    border-bottom-right-radius: 30px;
+    display: flex;
+    flex-direction: column;
+    margin-bottom: 11px;
+    padding: 8px 18px;
+    width: 100%;
+}
+
+.damage-cat-form details > div {
+    display: grid;
+    grid-auto-rows: 1fr;
+    grid-auto-columns: 1fr;
+    grid-template-columns: repeat(auto-fit, minmax(128px, max-content));
+}
+
+#damage-simulation-content .item-container {
+    position: relative;
+    display: flex;
+    flex-flow: column nowrap;
+    align-items: center;
+    justify-content: center;
+    background-image: url("../../svg/soldier-loadout-equipment-slot-border.svg");
+    cursor: pointer;
+    flex-shrink: 0;
+    padding: 0.5rem 1.25rem;
+    height: 100%;
+    gap: 0.5rem;
+}
+
+.damage-option-excl .item-container img {
+    width: 72px;
+    height: 48px;
+    object-fit: contain;
+}
+
+#damage-simulation-content .item-container img.item-stats-header-img {
+    width: 16px;
+    height: 16px;
+}
+
+#damage-results {
+    padding: 1rem;
+}
+
+.damage-option-excl[data-item-id] .item-help-button {
+    background-image: url("../../svg/soldier-loadout-equipment-slot-help-box.svg");
+    left: 8px;
+
+    cursor: help;
+    background-color: rgba(0, 0, 0, 0.05);
+    background-size: contain;
+    object-fit: contain;
+    border: none;
+    box-shadow: none;
+
+    position: absolute;
+    bottom: 6px;
+
+    display: none;
+    pointer-events: all;
+    width: 48px;
+    height: 16px;
+}
+
+.damage-option-excl[data-item-id]:hover .item-help-button {
+    display: block;
+}
+
+.damage-option-excl[data-item-id] .item-help-button:hover {
+    background-color: rgba(71, 118, 120, 0.6);
+}
+
+.damage-option-excl, .damage-option {
+    padding: 6px 3px;
+}
+
+.damage-option img {
+    background-color: transparent;
+    height: 50px;
+    min-width: 0px;
+    object-fit: contain;
+    margin: 0 auto;
+}
+
+.damage-perk img {
+    background-color: var(--color-strong);
+    height: 50px;
+}
+
+.damage-option-excl > input, .damage-option > input {
+    display: none;
+}
+
+.item-container > .item-container-name {
+    text-align: center;
+    word-break: break-word;
+}
+
+.damage-option .item-container input {
+    width: 75%;
+    margin: 0 auto;
+}
+
+#damage-simulation-content .damage-option-excl .perk-off ~ .item-container, #damage-simulation-content .damage-option .perk-off ~ .item-container {
+    background-color: rgba(100, 0, 0, 0.3);
+}
+
+#damage-simulation-content .damage-perk .perk-off ~ .item-container img {
+    background-color: rgba(255, 0, 0, 0.6);
+}
+
+#damage-simulation-content .damage-option-excl > input:checked ~ .item-container, #damage-simulation-content .damage-option > input:checked ~ .item-container {
+    background-color: rgba(71, 118, 120, 0.3);
+}
+
+#damage-simulation-content .damage-option-excl > input.perk-off:checked ~ .item-container, #damage-simulation-content .damage-option > input.perk-off:checked ~ .item-container {
+    background-color: rgba(255, 118, 120, 0.3);
+}
+
+#damage-simulation-content .item-container .damage-label {
+    display: inline-flex;
+    align-items: center;
+}
+
+#damage-form-preview-data {
+    display: flex;
+    flex-flow: row wrap;
+    align-items: center;
+    justify-content: center;
+}
+
+#damage-form-preview-data .damage-preview-actions {
+    display: flex;
+    margin: 1rem;
+    align-items: center;
+    justify-content: center;
+}
+
+#damage-form-preview-data .preview-new-row {
+    width: 100%;
+}
+
+#damage-form-preview-data #damage-form-preview-perks {
+    display: flex;
+    flex-flow: row wrap;
+    justify-content: center;
+    align-items: center;
+    gap: 5px;
+}
+
+#damage-form-preview-data #damage-form-preview-perks img {
+    height: 50px;
+    min-width: 0px;
+    object-fit: contain;
+    margin: 0 auto;
+}
+
+#damage-form-preview-data #damage-form-preview-perks img.perk-icon {
+    background-color: var(--color-strong);
+}
+
+#damage-result-table thead td {
+    background-color: var(--color-bg-subtle);
+
+    border: 1px solid var(--color-border-subtle);
+    padding: 4px 7px;
+
+    /* collapse borders */
+    margin-left: -1px;
+    margin-top: -1px;
+}
+
+#damage-result-table tbody td {
+    border: 1px solid var(--color-border-subtle);
+    padding: 4px 7px;
+
+    /* collapse borders */
+    margin-left: -1px;
+    margin-top: -1px;
+}
+
+#damage-form-preview-data .damage-form-preview-label {
+    font-weight: bold;
+}
+
+#damage-form-preview-data .damage-form-preview-column {
+    margin: 3px 6px;
+    display: flex;
+    flex-flow: column nowrap;
+    align-items: center;
+}
+
+#damage-form-preview-data input:read-only {
+    border: none;
+    background: transparent;
+    text-align: center;
+    user-select: none;
+    font-size: 1.5rem;
+}

--- a/assets/css/widgets.css
+++ b/assets/css/widgets.css
@@ -35,3 +35,7 @@
 
     --icon-image-size: calc(100% - 1em);
 }
+
+[data-page-on-click='damage-calculator-page'] {
+    cursor: pointer;
+}

--- a/assets/data/damage-bonuses.json
+++ b/assets/data/damage-bonuses.json
@@ -348,7 +348,7 @@
             "category": "perk"
         },
         {
-            "name": "Combat Stims (Requires cover)",
+            "name": "Combat Stims",
             "value": 0.4,
             "icon": "assets/img/item-icons/combat_stims.png",
             "category": "equipment"

--- a/assets/data/damage-bonuses.json
+++ b/assets/data/damage-bonuses.json
@@ -1,0 +1,505 @@
+{
+    "mwd_bonuses": [
+        {
+            "name": "Ranger",
+            "flat": 1,
+            "category": "perk",
+            "icon": "assets/img/perk-icons/ranger.png",
+            "requires": {
+                "type": [
+                    "loadout_primary",
+                    "loadout_secondary"
+                ]
+            }
+        },
+        {
+            "name": "Vital-Point Targeting",
+            "flat": 2,
+            "category": "perk",
+            "icon": "assets/img/perk-icons/vital_point_targeting.png",
+            "requires": {
+                "type": ["loadout_primary"]
+            }
+        },
+        {
+            "name": "Vital-Point Targeting (Sidearms)",
+            "flat": 1,
+            "category": "perk",
+            "icon": "assets/img/perk-icons/vital_point_targeting.png",
+            "requires": {
+                "category": [
+                    "machine_pistol",
+                    "pistol"
+                ]
+            }
+        },
+        {
+            "name": "Mayhem (Explosives/SAW/LMG)",
+            "flat": 2,
+            "category": "perk",
+            "icon": "assets/img/perk-icons/mayhem.png",
+            "requires": {
+                "or": {
+                    "category": [
+                        "saw",
+                        "lmg"
+                    ],
+                    "type": ["loadout_equipment"]
+                }
+            }
+        },
+        {
+            "name": "Mayhem (Strike/Sniper Rifles)",
+            "flat": 4,
+            "category": "perk",
+            "icon": "assets/img/perk-icons/mayhem.png",
+            "requires": {
+                "category": [
+                    "marksman_rifle",
+                    "sniper_rifle"
+                ]
+            }
+        },
+        {
+            "name": "In The Zone (-1 per ITZ proc)",
+            "adjustable": true,
+            "category": "perk",
+            "max": 0,
+            "icon": "assets/img/perk-icons/in_the_zone.png"
+        },
+        {
+            "name": "Sapper (AP/HE)",
+            "flat": 1,
+            "category": "perk",
+            "icon": "assets/img/perk-icons/sapper.png",
+            "requires": {
+                "id": [
+                    "item_he_grenade",
+                    "item_ap_grenade"
+                ]
+            }
+        },
+        {
+            "name": "Sapper (Plasma)",
+            "flat": 2,
+            "category": "perk",
+            "requires": {
+                "id": [
+                    "item_alien_grenade"
+                ]
+            },
+            "icon": "assets/img/perk-icons/sapper.png"
+        },
+        {
+            "name": "Alien Grenades (AP Grenades Only)",
+            "flat": 2,
+            "category": "upgrade",
+            "requires": {
+                "id": [
+                    "item_ap_grenade"
+                ]
+            },
+            "icon": "assets/img/foundry-icons/alien_grenades.png"
+        },
+        {
+            "name": "Weapon Enchancements (Alloy-Jacketed Rounds/Enhanced Beam Optics/Plasma Stellerator)",
+            "flat": 1,
+            "category": "equipment",
+            "requires": {
+                "type": ["loadout_primary"]
+            },
+            "icon": "assets/img/foundry-icons/enhanced_ballistics.png"
+        },
+        {
+            "name": "Reflex Pistols",
+            "flat": 1,
+            "category": "upgrade",
+            "icon": "assets/img/foundry-icons/reflex_pistols.png",
+            "requires": {
+                "category": [
+                    "machine_pistol",
+                    "pistol"
+                ]
+            }
+        },
+        {
+            "name": "Enhanced Plasma",
+            "flat": 1,
+            "category": "upgrade",
+            "icon": "assets/img/foundry-icons/enhanced_plasma.png",
+            "requires": {
+                "weapon_tier": [
+                    "plasma"
+                 ]
+            }
+        },
+        {
+            "name": "Heavy Plasma Rifle (Steadied)",
+            "flat": 1,
+            "category": "weapon",
+            "icon": "assets/img/item-icons/heavy_plasma_rifle.png",
+            "requires": {
+                "id": [
+                    "item_heavy_plasma_rifle"
+                 ]
+            }
+        },
+        {
+            "name": "Plasma Dragon (Flying Targets Only)",
+            "flat": 1,
+            "category": "weapon",
+            "icon": "assets/img/item-icons/plasma_dragon.png",
+            "requires": {
+                "id": [
+                    "item_plasma_dragon"
+                 ]
+            }
+        },
+        {
+            "name": "Particle Cannon (Robotic Targets Only)",
+            "flat": 1,
+            "category": "weapon",
+            "icon": "assets/img/item-icons/particle_cannon.png",
+            "requires": {
+                "id": [
+                    "item_particle_cannon"
+                 ]
+            }
+        }
+    ],
+    "mwd_crit_bonuses": [
+        {
+            "name": "Targeting Module",
+            "flat": 1,
+            "category": "equipment",
+            "icon": "assets/img/item-icons/targeting_module.png"
+        },
+        {
+            "name": "Precision Shot (Ballistics/Laser/Gauss) (Snipers only)",
+            "flat": 2,
+            "category": "actionoverride",
+            "icon": "assets/img/perk-icons/precision_shot.png",
+            "requires": {
+                "id": [
+                    "item_sniper_rifle",
+                    "item_laser_sniper_rifle",
+                    "item_gauss_long_rifle"
+                 ]
+            }
+        },
+        {
+            "name": "Precision Shot (Pulse) (Snipers only)",
+            "flat": 3,
+            "category": "actionoverride",
+            "icon": "assets/img/perk-icons/precision_shot.png",
+            "requires": {
+                "id": [
+                    "item_pulse_sniper_rifle"
+                 ]
+            }
+        },
+        {
+            "name": "Precision Shot (Plasma) (Snipers only)",
+            "flat": 4,
+            "category": "actionoverride",
+            "icon": "assets/img/perk-icons/precision_shot.png",
+            "requires": {
+                "id": [
+                    "item_plasma_sniper_rifle"
+                 ]
+            }
+        },
+        {
+            "name": "Bring em' on (+1 for 1-2 enemies, +2 for 3-4, +3 for 5-6, +4 for 7+)",
+            "adjustable": true,
+            "min": 1,
+            "max": 4,
+            "category": "perk",
+            "icon": "assets/img/perk-icons/bring_em_on.png"
+        },
+        {
+            "name": "Killer Instinct",
+            "mult": 0.34,
+            "round": "up",
+            "category": "perk",
+            "icon": "assets/img/perk-icons/killer_instinct.png"
+        },
+        {
+            "name": "Plasma Rifle (Biological Targets Only)",
+            "flat": 1,
+            "category": "weapon",
+            "icon": "assets/img/item-icons/plasma_rifle.png",
+            "requires": {
+                "id": [
+                    "item_plasma_rifle"
+                 ]
+            }
+        },
+        {
+            "name": "Reflex Cannon (Targets Within 4 Tiles Only)",
+            "flat": 1,
+            "category": "weapon",
+            "icon": "assets/img/item-icons/reflex_cannon.png",
+            "requires": {
+                "id": [
+                    "item_reflex_cannon"
+                 ]
+            }
+        },
+        {
+            "name": "Reflex Rifle (Flanked or Exposed Targets Only)",
+            "flat": 1,
+            "category": "weapon",
+            "icon": "assets/img/item-icons/reflex_rifle.png",
+            "requires": {
+                "id": [
+                    "item_reflex_rifle"
+                 ]
+            }
+        },
+        {
+            "name": "Plasma Sniper Rifle (Targets Further Than 23 Tiles Only)",
+            "flat": 1,
+            "category": "weapon",
+            "icon": "assets/img/item-icons/plasma_sniper_rifle.png",
+            "requires": {
+                "id": [
+                    "item_plasma_sniper_rifle"
+                 ]
+            }
+        }
+    ],
+    "bwd_penalties": [
+        {
+            "name": "Flush",
+            "mult": 0.5,
+            "use_bwd": true,
+            "round": "down",
+            "category": "actionoverride",
+            "icon": "assets/img/perk-icons/flush.png",
+            "requires": {
+                "type": [
+                    "loadout_primary"
+                ]
+            }
+        },
+        {
+            "name": "Shredder Rocket",
+            "mult": 0.6,
+            "use_bwd": true,
+            "round": "down",
+            "category": "actionoverride",
+            "icon": "assets/img/perk-icons/shredder_ammo.png",
+            "requires": {
+                "id": [
+                    "item_rocket_launcher",
+                    "item_recoilless_rifle",
+                    "item_blaster_launcher"
+                 ]
+            }
+        },
+        {
+            "name": "Disabling Shot",
+            "override": 1,
+            "category": "actionoverride",
+            "icon": "assets/img/perk-icons/disabling_shot.png",
+            "requires": {
+                "type": [
+                    "loadout_primary"
+                ]
+            },
+            "disables": [
+                "Mayhem"
+            ]
+        }
+    ],
+    "flat_dr": [
+        {
+            "name": "Iron Skin",
+            "flat": 1.0,
+            "icon": "assets/img/perk-icons/iron_skin.png",
+            "category": "perk"
+        },
+        {
+            "name": "Damage Control",
+            "flat": 1.5,
+            "icon": "assets/img/perk-icons/damage_control.png",
+            "category": "perk"
+        },
+        {
+            "name": "Mind Merge (Caster Will/50)",
+            "adjustable": true,
+            "icon": "assets/img/perk-icons/psi_mind_merge.png",
+            "category": "perk",
+            "min": 0
+        },
+        {
+            "name": "One for All",
+            "flat": 1.0,
+            "icon": "assets/img/perk-icons/one_for_all.png",
+            "category": "perk"
+        }
+    ],
+    "percent_dr": [
+        {
+            "name": "Psi Shield (Mechtoid)",
+            "value": 0.5,
+            "icon": "assets/img/perk-icons/psi_mind_merge.png",
+            "category": "perk"
+        },
+        {
+            "name": "Combat Stims (Requires cover)",
+            "value": 0.6,
+            "negate_by_flanking": true,
+            "icon": "assets/img/item-icons/combat_stims.png",
+            "category": "equipment"
+        },
+        {
+            "name": "Chitin Platins/Chryssalids (Only against Melee)",
+            "value": 0.6,
+            "icon": "assets/img/enemy-icons/chryssalid.png",
+            "category": "equipment"
+        },
+        {
+            "name": "Shock-Absorbent Armor (If source is within 4 tiles)",
+            "value": 0.667,
+            "icon": "assets/img/perk-icons/shock_absorbent_armor.png",
+            "category": "perk"
+        },
+        {
+            "name": "Absorption Fields",
+            "value": 0.667,
+            "dmg_mod": -2,
+            "icon": "assets/img/perk-icons/absorption_fields.png",
+            "category": "perk"
+        }
+    ],
+    "low_cover_dr": 0.667,
+    "full_cover_dr": 1,
+    "cover_dr": [
+        {
+            "name": "Hunker Down",
+            "mult": 1.0,
+            "category": "cover",
+            "icon": "assets/img/perk-icons/low_profile.png"
+        },
+        {
+            "name": "Fortiores Una",
+            "mult": 1.0,
+            "category": "perk",
+            "icon": "assets/img/perk-icons/fortiores_una.png"
+        },
+        {
+            "name": "Will to Survive",
+            "flat": 1.5,
+            "category": "perk",
+            "icon": "assets/img/perk-icons/will_to_survive.png"
+        }
+    ],
+    "dr_pierce": [
+        {
+            "name": "Combined Arms",
+            "flat": 1.0,
+            "category": "perk",
+            "icon": "assets/img/perk-icons/combined_arms.png"
+        },
+        {
+            "name": "Armor-Piercing Ammo",
+            "flat": 2.0,
+            "category": "equipment",
+            "requires": {
+                "type": ["loadout_primary"]
+            },
+            "icon": "assets/img/item-icons/armor_piercing_ammo.png"
+        },
+        {
+            "name": "Gauss Weapons",
+            "flat": 0.34,
+            "category": "passive",
+            "icon": "assets/img/item-icons/gauss_rifle.png",
+            "requires": {
+                "weapon_tier": [
+                    "gauss"
+                 ]
+            }
+        },
+        {
+            "name": "Quenchguns (Only applies to gauss weapons)",
+            "flat": 0.33,
+            "category": "upgrade",
+            "icon": "assets/img/foundry-icons/quenchguns.png",
+            "requires": {
+                "weapon_tier": [
+                    "gauss"
+                 ]
+            }
+        },
+        {
+            "name": "Acided",
+            "min": 3,
+            "percentage": 0.5,
+            "category": "perk",
+            "icon": "assets/img/perk-icons/acid_spit.png"
+        },
+        {
+            "name": "Breaching Ammo",
+            "category": "equipment",
+            "override_shotgun": true,
+            "requires": {
+                "category": [
+                    "shotgun"
+                ]
+            },
+            "icon": "assets/img/item-icons/breaching_ammo.png"
+        }
+    ],
+    "flat_bonuses": [
+        {
+            "name": "Shredder Ammo",
+            "mult": 0.4,
+            "round": "down",
+            "min": 1,
+            "category": "perk",
+            "icon": "assets/img/perk-icons/shredder_ammo.png"
+        },
+        {
+            "name": "HEAT Ammo/Warheads",
+            "mult": 0.5,
+            "use_bwd": true,
+            "round": "down",
+            "ignore_dr": true,
+            "min": 1,
+            "category": "perk",
+            "icon": "assets/img/perk-icons/heat_ammo.png",
+            "requires": {
+                "or": {
+                    "type": ["loadout_primary"],
+                    "category": [
+                        "rocket_launcher"
+                    ],
+                    "id": [
+                        "item_grenade_launcher",
+                        "item_proximity_mine_launcher"
+                    ]
+                }
+            }
+        },
+        {
+            "name": "Flak Ammo",
+            "mult": 0.2,
+            "use_bwd": true,
+            "round": "down",
+            "min": 1,
+            "category": "equipment",
+            "icon": "assets/img/item-icons/flak_ammo.png",
+            "requires": {
+                "or": {
+                    "category": [
+                        "rocket_launcher"
+                    ],
+                    "type": ["loadout_primary"]
+                }
+            }
+        }
+    ]
+}

--- a/assets/data/damage-bonuses.json
+++ b/assets/data/damage-bonuses.json
@@ -350,7 +350,6 @@
         {
             "name": "Combat Stims (Requires cover)",
             "value": 0.4,
-            "negate_by_flanking": true,
             "icon": "assets/img/item-icons/combat_stims.png",
             "category": "equipment"
         },

--- a/assets/data/damage-bonuses.json
+++ b/assets/data/damage-bonuses.json
@@ -349,26 +349,26 @@
         },
         {
             "name": "Combat Stims (Requires cover)",
-            "value": 0.6,
+            "value": 0.4,
             "negate_by_flanking": true,
             "icon": "assets/img/item-icons/combat_stims.png",
             "category": "equipment"
         },
         {
             "name": "Chitin Platins/Chryssalids (Only against Melee)",
-            "value": 0.6,
+            "value": 0.4,
             "icon": "assets/img/enemy-icons/chryssalid.png",
             "category": "equipment"
         },
         {
             "name": "Shock-Absorbent Armor (If source is within 4 tiles)",
-            "value": 0.667,
+            "value": 0.33,
             "icon": "assets/img/perk-icons/shock_absorbent_armor.png",
             "category": "perk"
         },
         {
             "name": "Absorption Fields",
-            "value": 0.667,
+            "value": 0.40,
             "dmg_mod": -2,
             "icon": "assets/img/perk-icons/absorption_fields.png",
             "category": "perk"
@@ -408,7 +408,13 @@
             "flat": 2.0,
             "category": "equipment",
             "requires": {
-                "type": ["loadout_primary"]
+                "not": {
+                    "category": [
+                        "shotgun",
+                        "machine_pistol",
+                        "pistol"
+                    ]
+                }
             },
             "icon": "assets/img/item-icons/armor_piercing_ammo.png"
         },
@@ -489,7 +495,7 @@
             "mult": 0.2,
             "use_bwd": true,
             "round": "down",
-            "min": 1,
+            "min": 2,
             "category": "equipment",
             "icon": "assets/img/item-icons/flak_ammo.png",
             "requires": {

--- a/assets/data/damage-bonuses.json
+++ b/assets/data/damage-bonuses.json
@@ -42,7 +42,8 @@
                 "or": {
                     "category": [
                         "saw",
-                        "lmg"
+                        "lmg",
+                        "rocket_launcher"
                     ],
                     "type": ["loadout_equipment"]
                 }
@@ -281,7 +282,10 @@
                 "type": [
                     "loadout_primary"
                 ]
-            }
+            },
+            "disables": [
+                "Mayhem"
+            ]
         },
         {
             "name": "Shredder Rocket",

--- a/assets/html/templates/custom-elements/enemy-infobox.html
+++ b/assets/html/templates/custom-elements/enemy-infobox.html
@@ -57,8 +57,8 @@
         <div id="enemy-infobox-damage-range-container" class="enemy-infobox-column-body-two-column-even">
             <div class="enemy-infobox-column-heading" data-tooltip-text="The damage dealt by this unit on a non-critical hit. Does not account for any perks.">Damage Range</div>
             <div class="enemy-infobox-column-heading" data-tooltip-text="The damage dealt by this unit on a critical hit. Does not account for any perks.">Crit Range</div>
-            <div id="enemy-infobox-damage-range" class="enemy-infobox-column-body"></div>
-            <div id="enemy-infobox-crit-range" class="enemy-infobox-column-body"></div>
+            <div id="enemy-infobox-damage-range" data-page-on-click="damage-calculator-page" class="enemy-infobox-column-body"></div>
+            <div id="enemy-infobox-crit-range" data-page-on-click="damage-calculator-page" class="enemy-infobox-column-body"></div>
         </div>
         <div id="enemy-infobox-perks-heading" class="enemy-infobox-column-heading">Perks and Abilities</div>
         <div id="enemy-infobox-perks-container" class="enemy-infobox-column-body"></div>

--- a/assets/html/templates/pages/damage-calculator-page.html
+++ b/assets/html/templates/pages/damage-calculator-page.html
@@ -101,19 +101,19 @@
                         <details>
                             <summary>Cover Options</summary>
                             <div class="item-entries-container">
-                                <div class="damage-option" onclick="document.getElementById('damage-cover-option-no').checked = true;">
+                                <div class="damage-option cover-option">
                                     <input type="radio" id="damage-cover-option-no" name="damage-cover" value="no" checked />
                                     <div class="item-container">
                                         <span class="item-container-name">No Cover</span>
                                     </div>
                                 </div>
-                                <div class="damage-option" onclick="document.getElementById('damage-cover-option-low').checked = true;">
+                                <div class="damage-option cover-option">
                                     <input type="radio" id="damage-cover-option-low" name="damage-cover" value="low" />
                                     <div class="item-container">
                                         <span class="item-container-name">Half Cover</span>
                                     </div>
                                 </div>
-                                <div class="damage-option" onclick="document.getElementById('damage-cover-option-full').checked = true;">
+                                <div class="damage-option cover-option">
                                     <input type="radio" id="damage-cover-option-full" name="damage-cover" value="high" />
                                     <div class="item-container">
                                         <span class="item-container-name">Full Cover</span>

--- a/assets/html/templates/pages/damage-calculator-page.html
+++ b/assets/html/templates/pages/damage-calculator-page.html
@@ -1,0 +1,197 @@
+<template id="damage-calculator-template">
+    <div class="section-content damage-calculator-section-content">
+        <div id="damage-calculator-options" class="flex-row">
+            <toggle-group id="damage-calculator-mode-toggle" options="Calculation,Simulation"></toggle-group>
+        </div>
+        <div id="damage-calculation-content" class="damage-calculator-content">
+            <table>
+                <tr>
+                    <td>Enter your modified weapon damage (this is the number you see in the preview): </td>
+                    <td><input id="dmg-input" type="number" min="1" value="1" /></td>
+                </tr>    
+                <tr>
+                    <td>Enter your critical chance (in integer): </td>
+                    <td><input id="crit-input" type="number" min="0" max="100" value="0" /></td>
+                </tr> 
+                <tr>
+                    <td>Enter your critical bonuses (before 1.5x multiplier): </td>
+                    <td><input id="crit-bonus-input" type="number" min="0" max="20" value="0" /></td>
+                </tr>
+            </table>
+            <div id="damage-results">
+        
+            </div>
+        </div>
+        <div id="damage-simulation-content" class="damage-calculator-content hidden-collapse">
+            <form id="damage-simulation-form">
+                <input id="is-explosive" type="hidden" name="explosive" value="false" />
+                <div id="damage-form-preview-data" class="damage-cat-form">
+                    <div class="damage-form-preview-column">
+                        <div class="damage-form-preview-label">Base Weapon Damage</div>
+                        <input type="number" id="damage-form-preview-bwd" min="0" value="0"></input>
+                    </div>
+                    <div class="damage-form-preview-column">
+                        <div class="damage-form-preview-label">BWD modifier</div>
+                        <input type="number" id="damage-form-preview-bwd-mod" value="0" readonly></input>
+                    </div>
+                    <div class="damage-form-preview-column">
+                        <div class="damage-form-preview-label">Crit modifier</div>
+                        <input type="number" id="damage-form-preview-mwd-crit-mod" value="0" readonly></input>
+                    </div>
+                    <div class="damage-form-preview-column">
+                        <div class="damage-form-preview-label">Base DR</div>
+                        <input type="number" id="damage-form-preview-base-dr" step="0.1" value="0"></input>
+                    </div>
+                    <div class="damage-form-preview-column">
+                        <div class="damage-form-preview-label">Crit Chance</div>
+                        <input type="number" id="damage-form-preview-crit-chance" step="1" value="0" min="0" max="100"></input>
+                    </div>
+                    <div class="damage-form-preview-column preview-new-row">
+                        <div class="damage-form-preview-label">Perks Selected</div>
+                        <div id="damage-form-preview-perks"></div>
+                    </div>
+                    <div class="damage-preview-actions preview-new-row">
+                        <button type="button" id="damage-simulation-result-btn" class="xcom">Calculate</button>
+                    </div>
+                </div>
+                <div id="damage-form-editor">
+                    <div id="damage-form-weapon" class="damage-cat-form">
+                        <details>
+                            <summary>Select a Weapon</summary>
+                            <div class="item-entries-container"></div>
+                        </details>
+                    </div>
+                    <div id="damage-form-perks" class="damage-cat-form">
+                        <details>
+                            <summary>Select Perks</summary>
+                            <div class="item-entries-container"></div>
+                        </details>
+                    </div>
+                    <div id="damage-form-equipments" class="damage-cat-form">
+                        <details>
+                            <summary>Select Equipments</summary>
+                            <div class="item-entries-container"></div>
+                        </details>
+                    </div>
+                    <div id="damage-form-upgrades" class="damage-cat-form">
+                        <details>
+                            <summary>Select Upgrades</summary>
+                            <div class="item-entries-container"></div>
+                        </details>
+                    </div>
+                    <div id="damage-form-target-armor" class="damage-cat-form">
+                        <details>
+                            <summary>Defender Armor</summary>
+                            <div class="item-entries-container"></div>
+                        </details>
+                    </div>
+                    <div id="damage-form-target-perks" class="damage-cat-form">
+                        <details>
+                            <summary>Defender Perks</summary>
+                            <div class="item-entries-container"></div>
+                        </details>
+                    </div>
+                    <div id="damage-form-target-equipments" class="damage-cat-form">
+                        <details>
+                            <summary>Defender Equipments</summary>
+                            <div class="item-entries-container"></div>
+                        </details>
+                    </div>
+                    <div id="damage-form-target-cover" class="damage-cat-form">
+                        <details>
+                            <summary>Cover Options</summary>
+                            <div class="item-entries-container">
+                                <div class="damage-option" onclick="document.getElementById('damage-cover-option-no').checked = true;">
+                                    <input type="radio" id="damage-cover-option-no" name="damage-cover" value="no" checked />
+                                    <div class="item-container">
+                                        <span class="item-container-name">No Cover</span>
+                                    </div>
+                                </div>
+                                <div class="damage-option" onclick="document.getElementById('damage-cover-option-low').checked = true;">
+                                    <input type="radio" id="damage-cover-option-low" name="damage-cover" value="low" />
+                                    <div class="item-container">
+                                        <span class="item-container-name">Half Cover</span>
+                                    </div>
+                                </div>
+                                <div class="damage-option" onclick="document.getElementById('damage-cover-option-full').checked = true;">
+                                    <input type="radio" id="damage-cover-option-full" name="damage-cover" value="high" />
+                                    <div class="item-container">
+                                        <span class="item-container-name">Full Cover</span>
+                                    </div>
+                                </div>
+                            </div>
+                        </details>
+                    </div>
+                </div>
+            </form>
+        </div> 
+    </div>
+</template>
+
+<template id="damage-weapon-selector">
+    <div class="damage-weapon damage-option-excl">
+        <input type="radio" name="damage-weapon" />
+        <div class="item-container">
+            <button class="item-help-button"></button>
+            <img>
+            <span class="item-container-name"></span>
+            <span class="damage-label">
+                <img class="item-stats-header-img" src="assets/img/item-stat-icons/damage.png"><span class="item-container-bwd"></span>
+            </span>
+        </div>
+    </div>
+</template>
+
+<template id="damage-armor-selector">
+    <div class="damage-armor damage-option-excl">
+        <input type="radio" name="damage-armor" />
+        <div class="item-container">
+            <button class="item-help-button"></button>
+            <img>
+            <span class="item-container-name"></span>
+            <span class="damage-label">
+                <img class="item-stats-header-img" src="assets/img/item-stat-icons/damage_reduction.png"><span class="item-container-dr"></span>
+            </span>
+        </div>
+    </div>
+</template>
+
+<template id="damage-option-selector">
+    <div class="damage-option">
+        <input class="damage-form-dynamic-input" type="checkbox" name="damage-repl-this" />
+        <div class="item-container">
+            <img>
+            <span class="item-container-name"></span>
+        </div>
+    </div>
+</template>
+
+<template id="damage-toggle">
+
+</template>
+
+
+
+<template id="template-damage-result-table">
+    <div class="damage-result-page-mini">
+        <div id="damage-result-container">
+            <div class="column-heading">Damage Simulation</div>
+            <div class="details-column-body">
+                <table id="damage-result-table">
+                    <thead>
+                        <tr>
+                            <td>HP Damage</td>
+                            <td>Damage Rolled</td>
+                            <td>Damage Blocked</td>
+                            <td>Chance</td>
+                            <td>Cumulative Chance</td>
+                        </tr>
+                    </thead>
+                    <tbody>
+
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</template>

--- a/assets/html/templates/pages/damage-calculator-page.html
+++ b/assets/html/templates/pages/damage-calculator-page.html
@@ -35,16 +35,16 @@
                         <input type="number" id="damage-form-preview-bwd-mod" value="0" readonly></input>
                     </div>
                     <div class="damage-form-preview-column">
+                        <div class="damage-form-preview-label">Crit Chance</div>
+                        <input type="number" id="damage-form-preview-crit-chance" step="1" value="0" min="0" max="100"></input>
+                    </div>
+                    <div class="damage-form-preview-column">
                         <div class="damage-form-preview-label">Crit modifier</div>
                         <input type="number" id="damage-form-preview-mwd-crit-mod" value="0" readonly></input>
                     </div>
                     <div class="damage-form-preview-column">
                         <div class="damage-form-preview-label">Base DR</div>
                         <input type="number" id="damage-form-preview-base-dr" step="0.1" value="0"></input>
-                    </div>
-                    <div class="damage-form-preview-column">
-                        <div class="damage-form-preview-label">Crit Chance</div>
-                        <input type="number" id="damage-form-preview-crit-chance" step="1" value="0" min="0" max="100"></input>
                     </div>
                     <div class="damage-form-preview-column preview-new-row">
                         <div class="damage-form-preview-label">Perks Selected</div>

--- a/assets/html/templates/pages/damage-calculator-page.html
+++ b/assets/html/templates/pages/damage-calculator-page.html
@@ -191,6 +191,7 @@
 
                     </tbody>
                 </table>
+                <div>Expected Damage: <span id="damage-result-expected"></span></div>
             </div>
         </div>
     </div>

--- a/assets/html/templates/pages/item-display-page.html
+++ b/assets/html/templates/pages/item-display-page.html
@@ -286,10 +286,10 @@
             </th>
         </tr>
         <tr>
-            <td id="weapon-stats-damage"></td>
-            <td id="weapon-stats-crit-damage"></td>
+            <td id="weapon-stats-damage" data-page-on-click="damage-calculator-page"></td>
+            <td id="weapon-stats-crit-damage" data-page-on-click="damage-calculator-page"></td>
             <td id="weapon-stats-aim"></td>
-            <td id="weapon-stats-crit-chance"></td>
+            <td id="weapon-stats-crit-chance" data-page-on-click="damage-calculator-page"></td>
             <td id="weapon-stats-mobility"></td>
             <td id="weapon-stats-dr-penetration"></td>
             <td id="weapon-stats-defense"></td>

--- a/assets/html/templates/pages/perk-tree-display-page.html
+++ b/assets/html/templates/pages/perk-tree-display-page.html
@@ -83,7 +83,7 @@
 
 <template id="template-perk-tree-display-page">
     <div id="perk-tree-content-section" class="section-content">
-        <div>
+        <div id="perk-tree-tree">
             <div class="perk-tree-row">
                 <div class="perk-tree-rank-icon"><img src="assets/img/soldier-rank-icons/specialist.png" /></div>
                 <div class="perk-tree-rank-name">

--- a/assets/js/custom-elements/enemy-infobox.js
+++ b/assets/js/custom-elements/enemy-infobox.js
@@ -228,9 +228,12 @@ class EnemyInfobox extends HTMLElement {
 
         const damageRangeElement = template.querySelector("#enemy-infobox-damage-range");
         damageRangeElement.textContent = `${damageRange.normal_min} - ${damageRange.normal_max}`;
+        damageRangeElement.setAttribute("data-pagearg-damage", stats.damage);
 
         const critRangeElement = template.querySelector("#enemy-infobox-crit-range");
         critRangeElement.textContent = `${damageRange.crit_min} - ${damageRange.crit_max}`;
+        critRangeElement.setAttribute("data-pagearg-damage", stats.damage);
+        critRangeElement.setAttribute("data-pagearg-crit", 100);
 
         // Hopefully this can be removed one day if I can figure out how much damage Mayhem gives to floaters and such
         if (enemyHasMayhem) {

--- a/assets/js/damage-calc.js
+++ b/assets/js/damage-calc.js
@@ -246,6 +246,7 @@ function damage_dice(dmg) {
           }
         });
 
+        eff_dmg = Math.max(0, eff_dmg);
         if (prev[eff_dmg]) {
           prev[eff_dmg][dr] = (prev[eff_dmg][dr] || 0) + pct;
         } else {

--- a/assets/js/damage-calc.js
+++ b/assets/js/damage-calc.js
@@ -1,0 +1,322 @@
+import { damageBonuses } from "./data-helper.js";
+
+function damage_dice(dmg) {
+    if (typeof dmg !== "number") {
+      throw "Must enter a number";
+    }
+    if (dmg < 0) {
+      throw "Must enter positive number";
+    }
+    if (dmg === 0) {
+      return [0];
+    }
+    const min_dmg = dmg - Math.ceil((dmg - 1) / 4);
+    const max_dmg = dmg + Math.ceil((dmg - 1) / 4);
+    const end_dice = (dmg - 1) % 4;
+    const damage_faces = new Array(max_dmg - min_dmg + 1).fill(0).map((_, i) => {
+      const curr_dmg = i + min_dmg;
+      if (end_dice !== 0 && (curr_dmg === min_dmg || curr_dmg === max_dmg)) {
+        return new Array(end_dice).fill(curr_dmg);
+      }
+  
+      return new Array(4).fill(curr_dmg);
+    });
+    return damage_faces.flat();
+  }
+  
+  function damage_normal(dmg) {
+    const faces = damage_dice(dmg);
+    const face_group = faces.reduce(
+      (c, d) => ({ ...c, [d]: 1 + (c[d] ?? 0) }),
+      {}
+    );
+    return Object.fromEntries(
+      Object.keys(face_group).map((k) => [k, face_group[k] / faces.length])
+    );
+  }
+  
+  function damage_crit(dmg) {
+    const faces = damage_dice(dmg);
+    const max_dmg = faces[faces.length - 1];
+    let face_group = {};
+    if (dmg % 2) {
+      const new_dice = faces
+        .map((i) => i + dmg * 0.5)
+        .map((i) => (i < max_dmg ? max_dmg : i));
+      face_group = new_dice.reduce(
+        (c, d) => ({ ...c, [d]: 1 + (c[d] ?? 0) }),
+        {}
+      );
+      face_group = Object.entries(face_group).reduce((c, d) => {
+        const cd = parseFloat(d[0]);
+        if (cd % 1 === 0) {
+          return { ...c, [cd]: d[1] };
+        }
+        const result = { ...c };
+        if (cd === faces[0] + (dmg * 0.5)) {
+          // For minimum damage, use reverse logic and apply ceiling damage first
+          if (d[1] <= 2) {
+            result[cd + 0.5] = d[1] + (result[cd + 0.5] ?? 0);
+          } else {
+            result[cd - 0.5] = d[1] - 2 + (result[cd - 0.5] ?? 0);
+            result[cd + 0.5] = 2 + (result[cd + 0.5] ?? 0);
+          }
+        }
+        else if (d[1] <= 2) {
+          result[cd - 0.5] = d[1] + (result[cd - 0.5] ?? 0);
+        } else {
+          result[cd - 0.5] = 2 + (result[cd - 0.5] ?? 0);
+          result[cd + 0.5] = d[1] - 2 + (result[cd + 0.5] ?? 0);
+        }
+        return result;
+      }, {});
+    } else {
+      face_group = faces.reduce((c, d) => {
+        let crit = d + dmg * 0.5;
+        if (crit < max_dmg) {
+          crit = max_dmg;
+        }
+        return { ...c, [crit]: 1 + (c[crit] ?? 0) };
+      }, {});
+    }
+    return Object.fromEntries(
+      Object.keys(face_group).map((k) => [k, face_group[k] / faces.length])
+    );
+  }
+
+  function add_chance(dmg, chance, dict) {
+    if (dmg < 0) {
+      dmg = 0;
+    }
+    if (!dict[dmg]) {
+      dict[dmg] = chance;
+    } else {
+      dict[dmg] += chance;
+    }
+  }
+
+  export function dmg_simulate(bwd, mwd_mod, critchance, critbonuses, bonuses, flat_dr, cover, targetBonuses, explosive) {
+    const dmg_rolls = dmg_range(bwd + mwd_mod, critbonuses);
+    const dmg_chances = {};
+    const crit_fixed = (parseInt(critchance) || 0) / 100;
+    Object.entries(dmg_rolls.normal).forEach(([dmg, chance]) => {
+      dmg = parseInt(dmg);
+      if (explosive) {
+        add_chance(dmg - 1, chance * 0.33 * (1 - crit_fixed), dmg_chances);
+        add_chance(dmg, chance * 0.34 * (1 - crit_fixed), dmg_chances);
+        add_chance(dmg + 1, chance * 0.33 * (1 - crit_fixed), dmg_chances);
+      } else {
+        add_chance(dmg, chance * (1 - crit_fixed), dmg_chances);
+      }
+    });
+    if (critchance) {
+      Object.entries(dmg_rolls.crit).forEach(([dmg, chance]) => {
+        if (explosive) {
+          add_chance(dmg - 1, chance * 0.33 * crit_fixed, dmg_chances);
+          add_chance(dmg, chance * 0.34 * crit_fixed, dmg_chances);
+          add_chance(dmg + 1, chance * 0.33 * crit_fixed, dmg_chances);
+        } else {
+          add_chance(dmg, chance * crit_fixed, dmg_chances);
+        }
+      });
+    }
+
+    let current_dr = parseFloat(flat_dr);
+    const pierce = bonuses.filter(b => b.bonuscat === "dr_pierce" && b.percentage !== undefined);
+    const post_pierce = bonuses.filter(b => b.bonuscat === "dr_pierce" && b.percentage === undefined);
+  
+    pierce.forEach(b => {
+      let pierce_amt = current_dr * b.percentage;
+      if (b.min !== undefined) {
+        pierce_amt = Math.max(pierce_amt, b.min);
+      }
+      if (b.max !== undefined) {
+        pierce_amt = Math.min(pierce_amt, b.max);
+      }
+      current_dr = Math.max(0, current_dr - pierce_amt);
+    });
+
+    const percent_dr = targetBonuses.filter(b => b.bonuscat === "percent_dr");
+    percent_dr.sort((a, b) => {
+      if (a.dmg_mod && b.dmg_mod) {
+        return b.dmg_mod - a.dmg_mod;
+      }
+      if (a.dmg_mod) {
+        return 1;
+      }
+      if (b.dmg_mod) {
+        return -1;
+      }
+      return 0;
+    });
+    const cover_dr = targetBonuses.filter(b => b.bonuscat === "cover_dr");
+    const dmg_table = Object.entries(dmg_chances).map(([dmg, pct]) => {
+      dmg = parseFloat(dmg);
+      let net_dmg = Math.max(0, dmg - current_dr);
+      percent_dr.forEach((dr) => {
+        if (dr.dmg_mod) {
+          if (net_dmg + dr.dmg_mod > 0) {
+            net_dmg = ((net_dmg + dr.dmg_mod) * dr.value) - dr.dmg_mod
+          }
+        } else {
+          net_dmg *= dr.value;
+        }
+      });
+
+      if (cover !== "no") {
+        let cover_mult = 1.0;
+        let cover_add = 0;
+
+        cover_dr.forEach((b) => {
+          if (b.mult) {
+            cover_mult += b.mult;
+          }
+          if (b.flat) {
+            cover_add += b.flat;
+          }
+        });
+        net_dmg = net_dmg - ((cover_mult * (cover === "low" ? damageBonuses.low_cover_dr : damageBonuses.full_cover_dr)) + cover_add)
+      }
+
+      let total_dr = dmg - net_dmg;
+      if (total_dr > 0) {
+        post_pierce.forEach(p => {
+          if (p.flat) {
+            total_dr -= p.flat;
+          }
+        });
+      }
+
+      if (total_dr > 0) {
+        if (bonuses.some((b) => b.bonuscat === "shotgun") && !bonuses.some((b) => b.override_shotgun)) {
+          total_dr *= 1.5;
+        }
+      } else {
+        total_dr = 0;
+      }
+
+      net_dmg = Math.max(0, dmg - total_dr);
+      return {
+        basedmg: dmg,
+        eff_dr: total_dr,
+        eff_dmg: net_dmg,
+        pct: pct
+      }
+    });
+    const bouns_dmg = bonuses.filter(b => b.bonuscat === "flat_bonuses");
+    bouns_dmg.sort(b => b.use_bwd);
+    const net_dmg = dmg_table.reduce((a, c) => {
+      const prev = {...a};
+
+      const addDamage = function (dr, pct) {
+        if (!pct) {
+          return;
+        }
+        const net_dmg = c.basedmg - dr;
+        let eff_dmg = net_dmg;
+
+        bouns_dmg.forEach((b) => {
+          let plus_dmg = 0;
+          if (b.ignore_dr || net_dmg > 0) {
+            if (b.use_bwd) {
+              plus_dmg = bwd * b.mult;
+            } else {
+              plus_dmg = net_dmg * b.mult;
+            }
+            
+            if (b.round === "down") {
+              plus_dmg = Math.floor(plus_dmg);
+            } else if (b.round === "up") {
+              plus_dmg = Math.ceil(plus_dmg);
+            } else {
+              plus_dmg = Math.round(plus_dmg);
+            }
+
+            if (b.min) {
+              plus_dmg = Math.max(b.min, plus_dmg);
+            }
+            if (b.max) {
+              plus_dmg = Math.min(b.max, plus_dmg);
+            }
+
+            if (plus_dmg) {
+              eff_dmg += plus_dmg;
+            }
+          }
+        });
+
+        if (prev[eff_dmg]) {
+          prev[eff_dmg][dr] = (prev[eff_dmg][dr] || 0) + pct;
+        } else {
+          prev[eff_dmg] = {[dr]: pct};
+        }
+      };
+
+      if (Math.floor(c.eff_dr) === c.eff_dr) {
+        addDamage(c.eff_dr, c.pct);
+      } else {
+        const floorP = c.eff_dr % 1;
+        addDamage(Math.floor(c.eff_dr), c.pct * (1 - floorP));
+        addDamage(Math.ceil(c.eff_dr), c.pct * floorP);
+      }
+
+      return prev;
+    }, {});
+    return net_dmg;
+  }
+  
+  export function dmg_range(dmg, crit_bonus) {
+    dmg = parseInt(dmg);
+    if (dmg === NaN) {
+      throw "Damage must be a number";
+    }
+    try {
+      if (crit_bonus !== null && crit_bonus !== undefined) {
+        crit_bonus = parseInt(crit_bonus);
+      } else {
+        crit_bonus = 0;
+      }
+    } catch {
+      crit_bonus = 0;
+    }
+    if (crit_bonus === NaN) {
+      throw "Crit bonus must be a number";
+    }
+    return {
+      normal: damage_normal(dmg),
+      crit: damage_crit(dmg + crit_bonus),
+    };
+  }
+  
+  export function dmg_with_crit(dmg, crit, crit_bonus) {
+    crit = parseFloat(crit);
+    if (crit < 0 || crit > 100) {
+      throw "Invalid crit amount";
+    }
+    const range = dmg_range(dmg, crit_bonus);
+    return Object.fromEntries(
+      Object.keys(range.normal)
+        .concat(Object.keys(range.crit))
+        .reduce((c, v) => {
+          if (c.includes(v)) {
+            return c;
+          } else {
+            return [...c, v];
+          }
+        }, [])
+        .map((dmg) => [
+          dmg,
+          (range.normal[dmg] ?? 0) * (1 - crit / 100) +
+            (range.crit[dmg] ?? 0) * (crit / 100),
+        ])
+        .filter(([_, chance]) => chance)
+        .reduce(
+          (c, [dmg, chance]) => [
+            ...c,
+            [dmg, { val: chance, culm: c.reduce((c, [_, v]) => c - v.val, 1) }],
+          ],
+          []
+        )
+    );
+  }
+  

--- a/assets/js/data-helper.js
+++ b/assets/js/data-helper.js
@@ -3,6 +3,7 @@ import * as Utils from "./utils.js";
 // Load all the JSON data at once
 const baseFacilityData = await fetch("assets/data/base-facilities.json").then(response => response.json());
 const councilRequestData = await fetch("assets/data/council-requests.json").then(response => response.json());
+const damageBonuses = await fetch("assets/data/damage-bonuses.json").then(response => response.json());
 const enemyData = await fetch("assets/data/enemies.json").then(response => response.json());
 const foundryProjectData = await fetch("assets/data/foundry-projects.json").then(response => response.json());
 const geneModData = await fetch("assets/data/gene-mods.json").then(response => response.json());
@@ -625,6 +626,7 @@ export {
     continents,
     councilRequests,
     countries,
+    damageBonuses,
     dataObjectById,
     enemies,
     enemyDamageRanges,

--- a/assets/js/page-controllers/damage-calculator-page.js
+++ b/assets/js/page-controllers/damage-calculator-page.js
@@ -1,0 +1,571 @@
+import { AppPage, PageHistoryState } from "./app-page.js";
+import { dmg_with_crit, dmg_simulate } from "../damage-calc.js";
+import { damageBonuses, items } from "../data-helper.js";
+import ItemDisplayPage from "./item-display-page.js";
+import PageManager from "../page-manager.js";
+import * as Templates from "../templates.js";
+import * as Utils from "../utils.js";
+import * as Modal from "../modal.js";
+
+class DamageCalculatorPage extends AppPage {
+    static pageId = "damage-calculator-page";
+
+    #damageInput = null;
+    #critInput = null;
+    #critBonusInput = null;
+    #damageResults = null;
+    #pageModeSelector = null;
+    #calculatorPage = null;
+    #simulatorPage = null;
+    #explosiveCheck = null;
+
+    // #region Damage Simulation
+    #damageFormPreview = null;
+
+    currentResults = null;
+
+    #previewPerks = null;
+
+    #simulationBWDInput = null;
+    #simulationBaseDRInput = null;
+    #simulationCritInput = null;
+
+    #simulationResultButton = null;
+
+    async populateSimulationForm(template, data) {
+        const bonuses = damageBonuses;
+        const allBonuses = Object.fromEntries(Object.entries(bonuses)
+            .filter(([_, v]) => typeof v.map === 'function')
+            .map(([bonuscat, v]) => v.map(b => { return {...b, "bonuscat": bonuscat}; })).flat().map(v => [v.name, v]));
+        const weapons = Object.entries(items).filter(([_, i]) => 
+            i.type_specific_data &&
+            i.type_specific_data.damage_min_normal
+        );
+
+        const explosiveCheck = this.#explosiveCheck;
+        this.#simulationResultButton = template.querySelector("#damage-simulation-result-btn");
+        this.#previewPerks = template.querySelector("#damage-form-preview-perks");
+
+        const reqCheck = function(requirements, itemName, item) {
+            const reqEntry = {...item.type_specific_data, "id": itemName, "name": item.name, "type": item.type};
+
+            const reqChecker = function([reqKey, reqVal]) {
+                if (reqKey === "or") {
+                    return Object.entries(reqVal).some(reqChecker);
+                }
+
+                if (typeof reqVal.some === "function") {
+                    return reqVal.some(checkVal => reqEntry[reqKey] === checkVal);
+                }
+
+                return reqEntry[reqKey] === reqVal;
+            }
+
+            return Object.entries(requirements).every(reqChecker);
+        }
+
+        const recalculateForm = function() {
+            let formData = new FormData(template.querySelector("#damage-simulation-form"));
+            const selectedWeapon = formData.get('damage-weapon');
+
+            let bwd = 0, mwdmod = 0, mwd_crit = 0;
+
+            const effectiveBonuses = [];
+            const effectiveBonusesTarget = [];
+    
+            if (selectedWeapon && items[selectedWeapon] && items[selectedWeapon].type_specific_data.damage_min_normal != null && items[selectedWeapon].type_specific_data.damage_max_normal != null) {
+                const weapEntry = items[selectedWeapon];
+                if (weapEntry.type_specific_data && weapEntry.type_specific_data.category === "shotgun") {
+                    effectiveBonuses.push({
+                        "name": "shotgun",
+                        "bonuscat": "shotgun"
+                    });
+                }
+                bwd = (weapEntry.type_specific_data.damage_min_normal + weapEntry.type_specific_data.damage_max_normal) / 2;
+                template.querySelectorAll("#damage-simulation-form .damage-form-dynamic-input").forEach((v) => {
+                    const attrValue = v.getAttribute("value");
+                    if (attrValue) {
+                        v.readOnly = false;
+                        const bonusEntry = allBonuses[attrValue];
+                        if (bonusEntry && bonusEntry.requires) {
+                            v.readOnly = !reqCheck(bonusEntry.requires, selectedWeapon, weapEntry);
+                        }
+                        if (!v.readOnly) {
+                            v.classList.remove("perk-off");
+                        } else {
+                            v.classList.add("perk-off");
+                        }
+                    }
+                });
+                this.#simulationBWDInput.readOnly = true;
+            } else {
+                template.querySelectorAll("#damage-simulation-form .damage-form-dynamic-input").forEach(v => {
+                    v.readOnly = false;
+                    v.classList.remove("perk-off");
+                });
+                bwd = parseInt(this.#simulationBWDInput.value);
+                this.#simulationBWDInput.readOnly = false;
+            }
+
+            template.querySelectorAll("#damage-simulation-form .damage-form-dynamic-input").forEach((v) => {
+                const attrValue = v.getAttribute("value");
+                if (attrValue && v.checked && !v.readOnly) {
+                    const bonusEntry = {...allBonuses[attrValue]};
+                    if (bonusEntry) {
+                        if (bonusEntry.adjustable) {
+                            const adjustedVal = v.parentNode.querySelector(".item-container input");
+                            if (adjustedVal) {
+                                bonusEntry.flat = parseFloat(adjustedVal.value);
+                            }
+                        }
+                        if (bonusEntry.category !== "passive" || selectedWeapon) {
+                            if (v.getAttribute("data-target")) {
+                                effectiveBonusesTarget.push(bonusEntry);
+                            } else {
+                                effectiveBonuses.push(bonusEntry);
+                            }
+                        }
+                    }
+                }
+            });
+
+            this.#simulationBWDInput.value = bwd;
+            const bwd_penalties = effectiveBonuses.filter(b => b.bonuscat === "bwd_penalties");
+            if (bwd_penalties && bwd_penalties.length) {
+                bwd_penalties.sort((a, b) => {
+                    if (a.override && !b.override) {
+                        return 1;
+                    } else if (!a.override && b.override) {
+                        return -1;
+                    }
+
+                    return 0;
+                });
+                let newBWD = bwd;
+                bwd_penalties.forEach((p) => {
+                    if (p.override !== undefined) {
+                        newBWD = p.override;
+                    } else {
+                        if (p.round === "up") {
+                            newBWD = Math.ceil(p.mult * newBWD);
+                        } else {
+                            newBWD = Math.floor(p.mult * newBWD);
+                        }
+                    }
+                    if (p.disables) {
+                        const nameFilter = b => b.name.startsWith(p.disables);
+                        for (let i = effectiveBonuses.findIndex(nameFilter); i >= 0; i = effectiveBonuses.findIndex(nameFilter)) {
+                            effectiveBonuses.splice(i, 1);
+                        }
+                    }
+                })
+                mwdmod = newBWD - bwd;
+            }
+            
+            const mwd_bonuses = effectiveBonuses.filter(b => b.bonuscat === "mwd_bonuses");
+            if (mwd_bonuses) {
+                mwd_bonuses.forEach((p) => {
+                    mwdmod += p.flat;
+                })
+            }
+            const mwd_crit_bonuses = effectiveBonuses.filter(b => b.bonuscat === "mwd_crit_bonuses");
+            if (mwd_crit_bonuses) {
+                mwd_crit_bonuses.forEach((p) => {
+                    if (p.flat) {
+                        mwd_crit += p.flat;
+                    }
+                    if (p.mult) {
+                        if (p.round === "up") {
+                            mwd_crit += Math.ceil(bwd * p.mult);
+                        } else {
+                            mwd_crit += Math.floor(bwd * p.mult);
+                        }
+                    }
+                })
+            }
+
+            const armorName = formData.get("damage-armor");
+            let armor_dr = parseFloat(this.#simulationBaseDRInput.value) || 0;
+            let flat_dr_sum = 0;
+            if (armorName != null && items[armorName]) {
+                armor_dr = items[armorName].type_specific_data.damage_reduction ?? 0;
+                this.#simulationBaseDRInput.readOnly = true;
+            } else {
+                this.#simulationBaseDRInput.readOnly = false;
+            }
+            const flat_dr = effectiveBonusesTarget.filter(b => b.bonuscat === "flat_dr");
+            if (flat_dr) {
+                flat_dr.filter(b => b.flat).forEach((b) => flat_dr_sum += b.flat);
+            }
+
+            template.querySelector("#damage-form-preview-bwd-mod").value = mwdmod;
+            template.querySelector("#damage-form-preview-mwd-crit-mod").value = mwd_crit;
+            this.#simulationBaseDRInput.value = armor_dr;
+            this.#previewPerks.innerText = "";
+            effectiveBonuses.forEach((v) => {
+                if (v.icon) {
+                    const icnDiv = document.createElement("div");
+                    const icn = document.createElement("img");
+                    icn.src = v.icon;
+                    if (v.category === "perk" || v.category === "actionoverride") {
+                        icn.classList.add("perk-icon");
+                    }
+                    icnDiv.append(icn);
+                    this.#previewPerks.append(icnDiv);
+                    const mousenterFunc = function (event) {
+                        event.preventDefault();
+                        event.stopPropagation();
+                        PageManager.instance.showTooltip(event.target.getBoundingClientRect(), v.name);
+                    };
+                    const mouseexitfunc = function (event) {
+                        event.preventDefault();
+                        event.stopPropagation();
+                        PageManager.instance.hideTooltip();
+                    }
+                    icnDiv.addEventListener("mouseenter", mousenterFunc);
+                    icnDiv.addEventListener("mouseout", mouseexitfunc);
+                }
+            });
+
+            const critchance = parseInt(template.querySelector("#damage-form-preview-crit-chance").value) || 0;
+
+            this.currentResults = dmg_simulate(bwd, mwdmod, critchance, mwd_crit, effectiveBonuses, flat_dr_sum + armor_dr, formData.get("damage-cover"), effectiveBonusesTarget, formData.get("explosive") === "true");
+            this.#simulationResultButton.addEventListener("click", async function() {
+                if (!this.currentResults) {
+                    return;
+                }
+                const template = await Templates.instantiateTemplate("assets/html/templates/pages/damage-calculator-page.html", "template-damage-result-table");
+
+                const resultTable = template.querySelector("#damage-result-table > tbody");
+
+                let culmchance = 1;
+                for (const value of Object.keys(this.currentResults)) {
+                    let tr = document.createElement("tr");
+                    let addedCulm = false;
+                    const hpDamage = document.createElement("td");
+                    hpDamage.setAttribute("rowspan", Object.entries(this.currentResults[value]).length);
+                    hpDamage.append(value);
+                    tr.append(hpDamage);
+                    for (const dr of Object.keys(this.currentResults[value])) {
+                        const dmgBase = document.createElement("td");
+                        const rolledDmg = parseInt(value) + parseInt(dr);
+                        dmgBase.append(rolledDmg);
+                        tr.append(dmgBase);
+                        resultTable.append(tr);
+                        const drtd = document.createElement("td");
+                        drtd.append(dr);
+                        tr.append(drtd);
+                        const chance = document.createElement("td");
+                        chance.append(this.currentResults[value][dr].toLocaleString(undefined, {
+                            style: "percent",
+                            minimumFractionDigits: 2,
+                          }));
+                        tr.append(chance);
+                        const culmtd = document.createElement("td");
+                        culmtd.append(culmchance.toLocaleString(undefined, {
+                            style: "percent",
+                            minimumFractionDigits: 2,
+                          }));
+                        culmchance -= this.currentResults[value][dr];
+                        if (!addedCulm) {
+                            culmtd.setAttribute("rowspan", Object.entries(this.currentResults[value]).length);
+                            tr.append(culmtd);
+                            addedCulm = true;
+                        }
+                        resultTable.append(tr);
+                        tr = document.createElement("tr");
+                    }
+                }
+
+                Modal.open(template, null, true);
+            }.bind(this));
+        }.bind(this);
+
+        weapons.sort(([nameA, a], [nameB, b]) => {
+            if (a.type_specific_data.weapon_tier && b.type_specific_data.weapon_tier) {
+                return a.type_specific_data.weapon_tier.localeCompare(b.type_specific_data.weapon_tier);
+            } else if (a.type_specific_data.weapon_tier) {
+                return -1;
+            } else if (b.type_specific_data.weapon_tier) {
+                return 1;
+            }
+            else {
+                if (a.type_specific_data.category && b.type_specific_data.category) {
+                    return a.type_specific_data.category.localeCompare(b.type_specific_data.category);
+                } else if (a.type_specific_data.category) {
+                    return -1;
+                } else if (b.type_specific_data.category) {
+                    return 1;
+                }
+                else {
+                    return nameA.localeCompare(nameB);
+                }
+            }
+        });
+
+        weapons.forEach(async ([name, w]) => {
+            const weapTemplate = await Templates.instantiateTemplate("assets/html/templates/pages/damage-calculator-page.html", "damage-weapon-selector");
+            const weapInput = weapTemplate.querySelector("input");
+            weapInput.value = name;
+            const bwd = (w.type_specific_data.damage_min_normal + w.type_specific_data.damage_max_normal) / 2;
+            weapTemplate.setAttribute("data-damage", bwd);
+            weapTemplate.setAttribute("data-item-id", name);
+            weapTemplate.querySelector("img").src = w.icon;
+            weapTemplate.querySelector(".item-container-name").textContent = w.name;
+            weapTemplate.querySelector(".item-container-bwd").textContent = bwd;
+            const helpButton = weapTemplate.querySelector("button.item-help-button");
+            helpButton.addEventListener("click", async(event) => {
+                event.stopPropagation();
+
+                const miniPage = await ItemDisplayPage.generateMiniPage(w);
+
+                Modal.open(miniPage, null, true);
+            });
+            weapTemplate.addEventListener("click", async(event) => {
+                event.stopPropagation();
+                
+                weapInput.checked = !weapInput.checked;
+                explosiveCheck.value = w.type === "loadout_equipment" || (w.type_specific_data && w.type_specific_data.category === "rocket_launcher") || name === "item_grenade_launcher" || name === "item_proximity_mine_launcher";
+                recalculateForm();
+            });
+        
+            template.querySelector("#damage-form-weapon > details > .item-entries-container").append(weapTemplate);
+        });
+
+        const perk_or_equipment_generate = async function (perk, cat, target) {
+            const perkTemplate = await Templates.instantiateTemplate("assets/html/templates/pages/damage-calculator-page.html", "damage-option-selector");
+            const perkInput = perkTemplate.querySelector("input");
+            perkInput.name = cat;
+            perkInput.value = perk.name;
+            if (target) {
+                perkInput.setAttribute("data-target", true);
+            }
+            
+            perkTemplate.querySelector("img").src = perk.icon;
+            perkTemplate.querySelector(".item-container-name").textContent = perk.name;
+            perkTemplate.setAttribute("data-item-id", perk.name);
+        
+            perkTemplate.addEventListener("click", async(event) => {
+                event.stopPropagation();
+                
+                perkInput.checked = !perkInput.checked;
+                recalculateForm();
+            });
+
+            if (perk.adjustable) {
+                const asj = document.createElementNS("http://www.w3.org/1999/xhtml", "input");
+                asj.type = "number";
+                asj.value = 0;
+                if (perk.min !== undefined) {
+                    asj.min = parseInt(perk.min);
+                }
+                if (perk.max !== undefined) {
+                    asj.max = parseInt(perk.max);
+                }
+                if (asj.min > asj.value) {
+                    asj.value = asj.min;
+                } else if (asj.max < asj.value) {
+                    asj.value = asj.max;
+                }
+                if (target) {
+                    asj.step = 0.01;
+                }
+                asj.addEventListener("click", (e) => e.stopPropagation());
+                asj.addEventListener("change", recalculateForm);
+                perkTemplate.querySelector(".item-container").append(asj);
+            }
+            if (perk.category === "actionoverride") {
+                perkInput.type = "radio";
+                perkInput.name = "actionoverride";
+                perkInput.setAttribute("data-cat", cat);
+                perkTemplate.classList.add("damage-perk");
+                if (target) {
+                    template.querySelector("#damage-form-target-perks > details > .item-entries-container").append(perkTemplate);
+                } else {
+                    template.querySelector("#damage-form-perks > details > .item-entries-container").append(perkTemplate);
+                }
+                return;
+            }
+            switch (perk.category) {
+                case "perk":
+                    perkTemplate.classList.add("damage-perk");
+                    if (target) 
+                    {
+                        template.querySelector("#damage-form-target-perks > details > .item-entries-container").append(perkTemplate);
+                    }
+                    else {
+                        template.querySelector("#damage-form-perks > details > .item-entries-container").append(perkTemplate);
+                    }
+                    break;
+                case "equipment":
+                case "weapon":
+                    if (target) 
+                    {
+                        template.querySelector("#damage-form-target-equipments > details > .item-entries-container").append(perkTemplate);
+                    }
+                    else {
+                        template.querySelector("#damage-form-equipments > details > .item-entries-container").append(perkTemplate);
+                    }
+                    break;
+                case "upgrade":
+                    template.querySelector("#damage-form-upgrades > details > .item-entries-container").append(perkTemplate);
+                    break;
+                case "cover":
+                    template.querySelector("#damage-form-target-cover > details > .item-entries-container").append(perkTemplate);
+                    break;
+                default:
+                    perkTemplate.classList.add("no-display");
+                    perkInput.checked = true;
+                    template.querySelector("#damage-simulation-form").append(perkTemplate);
+
+            }
+        }
+
+        bonuses.bwd_penalties.forEach((b) => perk_or_equipment_generate(b, "bwd_penalties"));
+        bonuses.mwd_bonuses.forEach((b) => perk_or_equipment_generate(b, "mwd_bonuses"));
+        bonuses.mwd_crit_bonuses.forEach((b) => perk_or_equipment_generate(b, "mwd_crit_bonuses"));
+        bonuses.dr_pierce.forEach((b) => perk_or_equipment_generate(b, "dr_pierce"));
+        bonuses.flat_bonuses.forEach((b) => perk_or_equipment_generate(b, "flat_bonuses"));
+
+        const dr_items = Object.entries(items).filter(([_, i]) => 
+            i.type_specific_data &&
+            i.type_specific_data.damage_reduction
+        );
+        const armors = dr_items.filter(([_, i]) => i.type !== "loadout_equipment");
+        armors.sort(([_, a], [__, b]) => a.type.localeCompare(b.type));
+        const flat_dr_equipments = dr_items.filter(([_, i]) => i.type === "loadout_equipment");
+        armors.forEach(async ([name, a]) => {
+            const armorTemplate = await Templates.instantiateTemplate("assets/html/templates/pages/damage-calculator-page.html", "damage-armor-selector");
+            const armorInput = armorTemplate.querySelector("input");
+            armorInput.value = name;
+            armorTemplate.setAttribute("data-dr", a.type_specific_data.damage_reduction);
+            armorTemplate.setAttribute("data-item-id", name);
+            armorTemplate.querySelector("img").src = a.icon;
+            armorTemplate.querySelector(".item-container-name").textContent = a.name;
+            armorTemplate.querySelector(".item-container-dr").textContent = a.type_specific_data.damage_reduction;
+            const helpButton = armorTemplate.querySelector("button.item-help-button");
+            helpButton.addEventListener("click", async(event) => {
+                event.stopPropagation();
+
+                const miniPage = await ItemDisplayPage.generateMiniPage(a);
+
+                Modal.open(miniPage, null, true);
+            });
+            armorTemplate.addEventListener("click", async(event) => {
+                event.stopPropagation();
+                
+                armorInput.checked = !armorInput.checked;
+                recalculateForm();
+            });
+        
+            template.querySelector("#damage-form-target-armor > details > .item-entries-container").append(armorTemplate);
+        });
+        const flar_dr_perks = flat_dr_equipments.map(([_, b]) => { 
+            const equipment_flat_dr_item = {
+                "name": b.name,
+                "value": b.type_specific_data.damage_reduction,
+                "category": "equipment",
+                "icon": b.icon,
+                "bonuscat": "flat_dr"
+            };
+            allBonuses[b.name] = equipment_flat_dr_item;
+            return equipment_flat_dr_item;
+        });
+        flar_dr_perks.forEach((b) => perk_or_equipment_generate(b, "flat_dr", true));
+        bonuses.flat_dr.forEach((b) => perk_or_equipment_generate(b, "flat_dr", true));
+        bonuses.percent_dr.forEach((b) => perk_or_equipment_generate(b, "percent_dr", true));
+        bonuses.cover_dr.forEach((b) => perk_or_equipment_generate(b, "cover_dr", true));
+
+        this.#simulationBWDInput.addEventListener("change", recalculateForm);
+        this.#simulationBaseDRInput.addEventListener("change", recalculateForm);
+        this.#simulationCritInput.addEventListener("change", recalculateForm);
+    }
+    // #endregion
+
+    async load(data) {
+        const template = await Templates.instantiateTemplate("assets/html/templates/pages/damage-calculator-page.html", "damage-calculator-template");
+
+        this.#damageInput = template.querySelector("#dmg-input");
+        this.#simulationBWDInput = template.querySelector("#damage-form-preview-bwd");
+        if (parseInt(data.damage)) {
+            this.#damageInput.value = data.damage;
+            this.#simulationBWDInput.value = data.damage;
+        }
+        this.#critInput = template.querySelector("#crit-input");
+        if (parseInt(data.crit)) {
+            this.#critInput.value = data.crit;
+        }
+        this.#critBonusInput = template.querySelector("#crit-bonus-input");
+        this.#simulationCritInput = template.querySelector("#damage-form-preview-crit-chance");
+        if (parseInt(data.critbonus)) {
+            this.#critBonusInput.value = data.critbonus;
+            this.#simulationCritInput.value = data.critbonus;
+        }
+        this.#simulationBaseDRInput = template.querySelector("#damage-form-preview-base-dr");
+        this.#damageInput.addEventListener("change", this._generateDamageTable.bind(this));
+        this.#critInput.addEventListener("change", this._generateDamageTable.bind(this));
+        this.#critBonusInput.addEventListener("change", this._generateDamageTable.bind(this));
+
+        this.#damageResults = template.querySelector("#damage-results");
+        this.#pageModeSelector = template.querySelector("#damage-calculator-mode-toggle");
+        this.#calculatorPage = template.querySelector("#damage-calculation-content");
+        this.#simulatorPage = template.querySelector("#damage-simulation-content");
+        this.#explosiveCheck = template.querySelector("#is-explosive");
+        this.#pageModeSelector.addEventListener("selectedOptionChanged", this._onSelectedPageModeChanged.bind(this));
+
+        this._generateDamageTable();
+
+        this.populateSimulationForm(template, data);
+
+        return {
+            body: template,
+            title: {
+                icon: "assets/img/item-stat-icons/damage.png",
+                text: "Damage Calculator"
+            }
+        };
+    }
+
+    _generateDamageTable() {
+        const headers = ["Damage", "% Chance", "% Cumulative"];
+        const sizes = new Array(3).fill("175px");
+        const values = [];
+
+        const dmg_table = dmg_with_crit(this.#damageInput.value, this.#critInput.value, this.#critBonusInput.value);
+
+        Object.keys(dmg_table).forEach((dmg) => {
+            values.push(dmg);
+            values.push(dmg_table[dmg].val.toLocaleString(undefined, {
+                style: "percent",
+                minimumFractionDigits: 2,
+              }));
+            values.push(dmg_table[dmg].culm.toLocaleString(undefined, {
+                style: "percent",
+                minimumFractionDigits: 2,
+              }));
+        });
+
+        const grid = Utils.createGrid(headers, sizes, values);
+
+        this.#damageResults.replaceChildren(grid);
+    }
+
+    _onSelectedPageModeChanged(event) {
+        const pageMode = event.detail.selectedOption.toLowerCase();
+
+        if (pageMode === "calculation") {
+            this.#calculatorPage.classList.remove("hidden-collapse");
+            this.#simulatorPage.classList.add("hidden-collapse");
+        }
+        else {
+            this.#calculatorPage.classList.add("hidden-collapse");
+            this.#simulatorPage.classList.remove("hidden-collapse");
+        }
+    }
+
+    makeHistoryState() {
+        return new PageHistoryState(this, { damage: this.#damageInput.value, crit: this.#critInput.value, critbonus: this.#critBonusInput.value });
+    }
+}
+
+export default DamageCalculatorPage

--- a/assets/js/page-controllers/damage-calculator-page.js
+++ b/assets/js/page-controllers/damage-calculator-page.js
@@ -256,6 +256,8 @@ class DamageCalculatorPage extends AppPage {
         const reqChecker = function([reqKey, reqVal]) {
             if (reqKey === "or") {
                 return Object.entries(reqVal).some(reqChecker);
+            } else if (reqKey === "not") {
+                return !Object.entries(reqVal).every(reqChecker);
             }
 
             if (typeof reqVal.some === "function") {

--- a/assets/js/page-controllers/damage-calculator-page.js
+++ b/assets/js/page-controllers/damage-calculator-page.js
@@ -281,6 +281,15 @@ class DamageCalculatorPage extends AppPage {
             }.bind(this));
         }.bind(this);
 
+        
+
+        template.querySelectorAll(".cover-option").forEach((c) => {
+            c.addEventListener("click", function () {
+                c.querySelector("input").checked = true;
+                recalculateForm();
+            });
+        });
+
         weapons.sort(([nameA, a], [nameB, b]) => {
             if (a.type_specific_data.weapon_tier && b.type_specific_data.weapon_tier) {
                 return a.type_specific_data.weapon_tier.localeCompare(b.type_specific_data.weapon_tier);

--- a/assets/js/page-controllers/damage-calculator-page.js
+++ b/assets/js/page-controllers/damage-calculator-page.js
@@ -41,6 +41,7 @@ class DamageCalculatorPage extends AppPage {
         const resultTable = template.querySelector("#damage-result-table > tbody");
 
         let culmchance = 1;
+        let expectedDamage = 0;
         for (const value of Object.keys(this.currentResults)) {
             let tr = document.createElement("tr");
             let addedCulm = false;
@@ -76,9 +77,12 @@ class DamageCalculatorPage extends AppPage {
                 }
                 resultTable.append(tr);
                 tr = document.createElement("tr");
+                expectedDamage += this.currentResults[value][dr] * parseInt(value);
             }
         }
-
+        template.querySelector("#damage-result-expected").append(expectedDamage.toLocaleString(undefined, {
+           maximumFractionDigits: 2,
+          }));
         Modal.open(template, null, true);
     }
 

--- a/assets/js/page-controllers/item-display-page.js
+++ b/assets/js/page-controllers/item-display-page.js
@@ -478,9 +478,14 @@ class ItemDisplayPage extends AppPage {
         const gridTemplate = await Templates.instantiateTemplate("assets/html/templates/pages/item-display-page.html", "template-item-weapon-stats-grid");
 
         gridTemplate.querySelector("#weapon-stats-damage").textContent = weaponData.damage_min_normal + " - " + weaponData.damage_max_normal;
+        gridTemplate.querySelector("#weapon-stats-damage").setAttribute("data-pagearg-damage", (weaponData.damage_min_normal + weaponData.damage_max_normal) / 2);
         gridTemplate.querySelector("#weapon-stats-crit-damage").textContent = weaponData.damage_min_crit + " - " + weaponData.damage_max_crit;
+        gridTemplate.querySelector("#weapon-stats-crit-damage").setAttribute("data-pagearg-damage", (weaponData.damage_min_normal + weaponData.damage_max_normal) / 2);
+        gridTemplate.querySelector("#weapon-stats-crit-damage").setAttribute("data-pagearg-crit", 100);
         gridTemplate.querySelector("#weapon-stats-aim").textContent = weaponData.aim || 0;
         gridTemplate.querySelector("#weapon-stats-crit-chance").textContent = weaponData.crit_chance || 0;
+        gridTemplate.querySelector("#weapon-stats-crit-chance").setAttribute("data-pagearg-damage", (weaponData.damage_min_normal + weaponData.damage_max_normal) / 2);
+        gridTemplate.querySelector("#weapon-stats-crit-chance").setAttribute("data-pagearg-crit", weaponData.crit_chance || 0);
         gridTemplate.querySelector("#weapon-stats-mobility").textContent = weaponData.mobility || 0;
         gridTemplate.querySelector("#weapon-stats-dr-penetration").textContent = weaponData.dr_penetration || 0;
         gridTemplate.querySelector("#weapon-stats-defense").textContent = weaponData.defense || 0;

--- a/assets/js/page-controllers/perk-tree-display-page.js
+++ b/assets/js/page-controllers/perk-tree-display-page.js
@@ -63,6 +63,9 @@ class PerkTreeDisplayPage extends AppPage {
         else if (data.displayMode == "psi-training") {
             return this._loadPsiTree();
         }
+        else if (data.displayMode == "single-perk" && data.itemId) {
+            return this._loadPerk(data.itemId);
+        }
         else {
             console.error(`Unknown display mode ${data.displayMode}`);
             return null;
@@ -186,6 +189,26 @@ class PerkTreeDisplayPage extends AppPage {
             }
         };
     }
+
+    async _loadPerk(perkId) {
+        const template = await Templates.instantiateTemplate("assets/html/templates/pages/perk-tree-display-page.html", "template-perk-tree-display-page");
+
+        template.querySelector("#perk-tree-tree").classList.add("no-display");
+        template.querySelector("#perk-tree-details-stat-bonuses").classList.add("no-display");
+        const perk = DataHelper.perks[perkId];
+        template.querySelector("#perk-tree-details").classList.remove("hidden");
+        template.querySelector("#perk-tree-details-name").textContent = perk.name;
+        template.querySelector("#perk-tree-details-description").textContent = perk.description;
+
+        return {
+            body: template,
+            title: {
+                icon: perk.icon,
+                text: perk.name
+            }
+        };
+    }
+
 
     _onGeneModClick(event) {
         event.preventDefault();

--- a/assets/js/page-manager.js
+++ b/assets/js/page-manager.js
@@ -8,6 +8,7 @@ import * as Utils from "./utils.js";
 import BaseFacilityPage from "./page-controllers/base-facility-page.js";
 import BaseFacilitiesBrowsePage from "./page-controllers/base-facilities-browse-page.js";
 import CampaignPlannerPage from "./page-controllers/campaign-planner-page.js";
+import DamageCalculatorPage from "./page-controllers/damage-calculator-page.js";
 import EnemyBrowsePage from "./page-controllers/enemy-browse-page.js";
 import EnemyDisplayPage from "./page-controllers/enemy-display-page.js";
 import FoundryProjectsBrowsePage from "./page-controllers/foundry-projects-browse-page.js";
@@ -33,6 +34,7 @@ const appPages = [
     BaseFacilityPage,
     BaseFacilitiesBrowsePage,
     CampaignPlannerPage,
+    DamageCalculatorPage,
     EnemyBrowsePage,
     EnemyDisplayPage,
     FoundryProjectsBrowsePage,

--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
 
     <link rel="stylesheet" href="assets/css/pages/base-facilities.css" />
     <link rel="stylesheet" href="assets/css/pages/campaign-planner-page.css" />
+    <link rel="stylesheet" href="assets/css/pages/damage-calculator-page.css" />
     <link rel="stylesheet" href="assets/css/pages/enemy-browse-page.css" />
     <link rel="stylesheet" href="assets/css/pages/enemy-display-page.css" />
     <link rel="stylesheet" href="assets/css/pages/home-page.css" />
@@ -143,6 +144,7 @@
 
                 <button data-page-on-click="loadout-selection-page" class="nav-button">Build Manager</button>
                 <button data-page-on-click="campaign-planner-page" class="nav-button">Campaign Planner (Beta)</button>
+                <button data-page-on-click="damage-calculator-page" class="nav-button">Damage Calculator</button>
             </div>
         </div>
 


### PR DESCRIPTION
Added damage calculator functionality, allow you to see the probability table of damage that can be rolled using a given damage value.
Also comes with a damage simulation page, allowing you to choose weapons, perks, and equipment for both attacker and defender, then producing a table to display the probability table of damage that could be dealt. Damage simulation page will also filter out most perks/weapons combinations that are invalid. Remaining combinations may be invalid in vanilla long war but could be achieved in training roulette+ that unrestricts all perks.

Bonus fix:
I also fix clicking perks getting an erroneous history page being saved, causing back buttons needing to be clicked an extra time, by making it actually navigate to a full screen perk page.