### PR TITLE
Alien deployments info

### DIFF
--- a/assets/data/enemy_deployments.json
+++ b/assets/data/enemy_deployments.json
@@ -1,0 +1,4930 @@
+{
+    "groups": {
+        "enemy_group_mechtoid": [ "enemy_mechtoid" ],
+        "enemy_group_exalt": [ "enemy_exalt_heavy", "enemy_exalt_medic", "enemy_exalt_operative", "enemy_exalt_sniper" ],
+        "enemy_group_exalt_elite": [ "enemy_exalt_elite_heavy", "enemy_exalt_elite_medic", "enemy_exalt_elite_operative", "enemy_exalt_elite_sniper" ]
+    },
+    "deployments": [
+        {
+            "alien_research": 0,
+            "aliens": {
+                "enemy_sectoid": {
+                    "normal_spawn": 0.76,
+                    "terror_spawn": 0,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_sectoid"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_sectoid"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_drone"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_sectoid"
+                        }
+                    ]
+                },
+                "enemy_drone": {
+                    "normal_spawn": 0.24,
+                    "terror_spawn": 0,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ]
+                },
+                "enemy_chryssalid": {
+                    "normal_spawn": 0,
+                    "terror_spawn": 1,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_chryssalid"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_chryssalid"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_chryssalid"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_zombie"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "alien_research": 28,
+            "aliens": {
+                "enemy_sectoid": {
+                    "normal_spawn": 0.29,
+                    "terror_spawn": 0,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_sectoid"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_sectoid"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_drone"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_sectoid"
+                        }
+                    ]
+                },
+                "enemy_drone": {
+                    "normal_spawn": 0.09,
+                    "terror_spawn": 0,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ]
+                },
+                "enemy_chryssalid": {
+                    "normal_spawn": 0,
+                    "terror_spawn": 0.62,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_chryssalid"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_chryssalid"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_chryssalid"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_zombie"
+                        }
+                    ]
+                },
+                "enemy_floater": {
+                    "normal_spawn": 0.37,
+                    "terror_spawn": 0.25,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_floater"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_floater"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_floater"
+                        }
+                    ]
+                },
+                "enemy_thin_man": {
+                    "normal_spawn": 0.35,
+                    "terror_spawn": 0.13,
+                    "supports": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_thin_man"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_seeker"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_thin_man"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_sectoid"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_thin_man"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "alien_research": 56,
+            "aliens": {
+                "enemy_sectoid": {
+                    "normal_spawn": 0.21,
+                    "terror_spawn": 0,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_sectoid"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_sectoid"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_drone"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_sectoid"
+                        }
+                    ]
+                },
+                "enemy_drone": {
+                    "normal_spawn": 0.06,
+                    "terror_spawn": 0,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ]
+                },
+                "enemy_chryssalid": {
+                    "normal_spawn": 0,
+                    "terror_spawn": 0.47,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_chryssalid"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_chryssalid"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_chryssalid"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_zombie"
+                        }
+                    ]
+                },
+                "enemy_floater": {
+                    "normal_spawn": 0.26,
+                    "terror_spawn": 0.19,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_floater"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_floater"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_floater"
+                        }
+                    ]
+                },
+                "enemy_thin_man": {
+                    "normal_spawn": 0.2,
+                    "terror_spawn": 0.09,
+                    "supports": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_thin_man"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_seeker"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_thin_man"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_sectoid"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_thin_man"
+                        }
+                    ]
+                },
+                "enemy_seeker": {
+                    "normal_spawn": 0.17,
+                    "terror_spawn": 0.25,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_seeker"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_seeker"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_seeker"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_drone"
+                        }
+                    ]
+                },
+                "enemy_muton": {
+                    "normal_spawn": 0.1,
+                    "terror_spawn": 0,
+                    "supports": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_floater"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_muton"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_muton"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_sectoid"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_floater"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "alien_research": 84,
+            "aliens": {
+                "enemy_sectoid": {
+                    "normal_spawn": 0.12,
+                    "terror_spawn": 0,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_sectoid"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_sectoid"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_drone"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_sectoid"
+                        }
+                    ]
+                },
+                "enemy_drone": {
+                    "normal_spawn": 0.06,
+                    "terror_spawn": 0,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ]
+                },
+                "enemy_chryssalid": {
+                    "normal_spawn": 0,
+                    "terror_spawn": 0.4,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_chryssalid"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_chryssalid"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_chryssalid"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_zombie"
+                        }
+                    ]
+                },
+                "enemy_floater": {
+                    "normal_spawn": 0.26,
+                    "terror_spawn": 0.17,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_floater"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_floater"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_floater"
+                        }
+                    ]
+                },
+                "enemy_thin_man": {
+                    "normal_spawn": 0.19,
+                    "terror_spawn": 0.08,
+                    "supports": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_thin_man"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_seeker"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_thin_man"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_sectoid"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_thin_man"
+                        }
+                    ]
+                },
+                "enemy_seeker": {
+                    "normal_spawn": 0.16,
+                    "terror_spawn": 0.21,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_seeker"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_seeker"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_seeker"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_drone"
+                        }
+                    ]
+                },
+                "enemy_muton": {
+                    "normal_spawn": 0.21,
+                    "terror_spawn": 0.09,
+                    "supports": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_floater"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_muton"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_muton"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_sectoid"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_floater"
+                        }
+                    ]
+                },
+                "enemy_cyberdisc": {
+                    "normal_spawn": 0,
+                    "terror_spawn": 0.05,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_cyberdisc"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_seeker"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "alien_research": 112,
+            "aliens": {
+                "enemy_sectoid": {
+                    "normal_spawn": 0.1,
+                    "terror_spawn": 0,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_sectoid"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_sectoid"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_drone"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_sectoid"
+                        }
+                    ]
+                },
+                "enemy_drone": {
+                    "normal_spawn": 0.06,
+                    "terror_spawn": 0,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ]
+                },
+                "enemy_chryssalid": {
+                    "normal_spawn": 0,
+                    "terror_spawn": 0.32,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_chryssalid"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_chryssalid"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_chryssalid"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_zombie"
+                        }
+                    ]
+                },
+                "enemy_floater": {
+                    "normal_spawn": 0.22,
+                    "terror_spawn": 0.14,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_floater"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_floater"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_floater"
+                        }
+                    ]
+                },
+                "enemy_thin_man": {
+                    "normal_spawn": 0.16,
+                    "terror_spawn": 0.06,
+                    "supports": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_thin_man"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_seeker"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_thin_man"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_sectoid"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_thin_man"
+                        }
+                    ]
+                },
+                "enemy_seeker": {
+                    "normal_spawn": 0.15,
+                    "terror_spawn": 0.17,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_seeker"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_seeker"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_seeker"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_drone"
+                        }
+                    ]
+                },
+                "enemy_muton": {
+                    "normal_spawn": 0.22,
+                    "terror_spawn": 0.07,
+                    "supports": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_floater"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_muton"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_muton"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_sectoid"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_floater"
+                        }
+                    ]
+                },
+                "enemy_cyberdisc": {
+                    "normal_spawn": 0.09,
+                    "terror_spawn": 0.24,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_cyberdisc"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_seeker"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "alien_research": 140,
+            "aliens": {
+                "enemy_sectoid": {
+                    "normal_spawn": 0.1,
+                    "terror_spawn": 0,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_sectoid"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_sectoid"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_drone"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_sectoid"
+                        }
+                    ]
+                },
+                "enemy_drone": {
+                    "normal_spawn": 0.05,
+                    "terror_spawn": 0,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ]
+                },
+                "enemy_chryssalid": {
+                    "normal_spawn": 0,
+                    "terror_spawn": 0.29,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_chryssalid"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_chryssalid"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_chryssalid"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_zombie"
+                        }
+                    ]
+                },
+                "enemy_floater": {
+                    "normal_spawn": 0.2,
+                    "terror_spawn": 0.11,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_floater"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_floater"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_floater"
+                        }
+                    ]
+                },
+                "enemy_thin_man": {
+                    "normal_spawn": 0.16,
+                    "terror_spawn": 0.06,
+                    "supports": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_thin_man"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_seeker"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_thin_man"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_sectoid"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_thin_man"
+                        }
+                    ]
+                },
+                "enemy_seeker": {
+                    "normal_spawn": 0.13,
+                    "terror_spawn": 0.15,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_seeker"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_seeker"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_seeker"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_drone"
+                        }
+                    ]
+                },
+                "enemy_muton": {
+                    "normal_spawn": 0.2,
+                    "terror_spawn": 0.06,
+                    "supports": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_floater"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_muton"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_muton"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_sectoid"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_floater"
+                        }
+                    ]
+                },
+                "enemy_cyberdisc": {
+                    "normal_spawn": 0.08,
+                    "terror_spawn": 0.21,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_cyberdisc"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_seeker"
+                        }
+                    ]
+                },
+                "enemy_muton_berserker": {
+                    "normal_spawn": 0,
+                    "terror_spawn": 0.03,
+                    "supports": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_muton"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_floater"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_muton_berserker"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_muton_berserker"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_floater"
+                        }
+                    ]
+                },
+                "enemy_mechtoid": {
+                    "normal_spawn": 0.08,
+                    "terror_spawn": 0.09,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_sectoid"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_mechtoid"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "alien_research": 168,
+            "aliens": {
+                "enemy_sectoid": {
+                    "normal_spawn": 0.09,
+                    "terror_spawn": 0,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_sectoid"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_sectoid"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_drone"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_sectoid"
+                        }
+                    ]
+                },
+                "enemy_drone": {
+                    "normal_spawn": 0.05,
+                    "terror_spawn": 0,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ]
+                },
+                "enemy_chryssalid": {
+                    "normal_spawn": 0,
+                    "terror_spawn": 0.26,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_chryssalid"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_chryssalid"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_chryssalid"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_zombie"
+                        }
+                    ]
+                },
+                "enemy_floater": {
+                    "normal_spawn": 0.06,
+                    "terror_spawn": 0.11,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_floater"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_floater"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_floater"
+                        }
+                    ]
+                },
+                "enemy_thin_man": {
+                    "normal_spawn": 0.15,
+                    "terror_spawn": 0.06,
+                    "supports": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_thin_man"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_seeker"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_thin_man"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_sectoid"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_thin_man"
+                        }
+                    ]
+                },
+                "enemy_seeker": {
+                    "normal_spawn": 0.12,
+                    "terror_spawn": 0.13,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_seeker"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_seeker"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_seeker"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_drone"
+                        }
+                    ]
+                },
+                "enemy_muton": {
+                    "normal_spawn": 0.19,
+                    "terror_spawn": 0.06,
+                    "supports": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_floater"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_muton"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_muton"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_sectoid"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_floater"
+                        }
+                    ]
+                },
+                "enemy_cyberdisc": {
+                    "normal_spawn": 0.08,
+                    "terror_spawn": 0.19,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_cyberdisc"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_seeker"
+                        }
+                    ]
+                },
+                "enemy_muton_berserker": {
+                    "normal_spawn": 0.2,
+                    "terror_spawn": 0.11,
+                    "supports": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_muton"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_floater"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_muton_berserker"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_muton_berserker"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_floater"
+                        }
+                    ]
+                },
+                "enemy_mechtoid": {
+                    "normal_spawn": 0.06,
+                    "terror_spawn": 0.08,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_sectoid"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_mechtoid"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "alien_research": 196,
+            "aliens": {
+                "enemy_sectoid": {
+                    "normal_spawn": 0.08,
+                    "terror_spawn": 0,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_sectoid"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_sectoid"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_drone"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_sectoid"
+                        }
+                    ]
+                },
+                "enemy_drone": {
+                    "normal_spawn": 0.03,
+                    "terror_spawn": 0,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ]
+                },
+                "enemy_chryssalid": {
+                    "normal_spawn": 0,
+                    "terror_spawn": 0.26,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_chryssalid"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_chryssalid"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_chryssalid"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_zombie"
+                        }
+                    ]
+                },
+                "enemy_floater": {
+                    "normal_spawn": 0.06,
+                    "terror_spawn": 0.05,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_floater"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_floater"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_floater"
+                        }
+                    ]
+                },
+                "enemy_thin_man": {
+                    "normal_spawn": 0.13,
+                    "terror_spawn": 0.05,
+                    "supports": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_thin_man"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_seeker"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_thin_man"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_sectoid"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_thin_man"
+                        }
+                    ]
+                },
+                "enemy_seeker": {
+                    "normal_spawn": 0.11,
+                    "terror_spawn": 0.14,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_seeker"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_seeker"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_seeker"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_drone"
+                        }
+                    ]
+                },
+                "enemy_muton": {
+                    "normal_spawn": 0.17,
+                    "terror_spawn": 0.05,
+                    "supports": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_floater"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_muton"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_muton"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_sectoid"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_floater"
+                        }
+                    ]
+                },
+                "enemy_cyberdisc": {
+                    "normal_spawn": 0.07,
+                    "terror_spawn": 0.18,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_cyberdisc"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_seeker"
+                        }
+                    ]
+                },
+                "enemy_muton_berserker": {
+                    "normal_spawn": 0.17,
+                    "terror_spawn": 0.1,
+                    "supports": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_muton"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_floater"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_muton_berserker"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_muton_berserker"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_floater"
+                        }
+                    ]
+                },
+                "enemy_mechtoid": {
+                    "normal_spawn": 0.06,
+                    "terror_spawn": 0.08,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_sectoid"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_mechtoid"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ]
+                },
+                "enemy_sectoid_commander": {
+                    "normal_spawn": 0.06,
+                    "terror_spawn": 0.05,
+                    "supports": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_outsider"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_sectoid"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_sectoid_commander"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_mechtoid"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_outsider"
+                        }
+                    ]
+                },
+                "enemy_group_mechtoid": {
+                    "normal_spawn": 0.06,
+                    "terror_spawn": 0.04,
+                    "supports": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_muton"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_sectoid"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_mechtoid"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_sectoid_commander"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_drone"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "alien_research": 224,
+            "aliens": {
+                "enemy_sectoid": {
+                    "normal_spawn": 0.06,
+                    "terror_spawn": 0,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_sectoid"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_sectoid"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_drone"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_sectoid"
+                        }
+                    ]
+                },
+                "enemy_drone": {
+                    "normal_spawn": 0.03,
+                    "terror_spawn": 0,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ]
+                },
+                "enemy_chryssalid": {
+                    "normal_spawn": 0,
+                    "terror_spawn": 0.2,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_chryssalid"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_chryssalid"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_chryssalid"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_zombie"
+                        }
+                    ]
+                },
+                "enemy_floater": {
+                    "normal_spawn": 0.04,
+                    "terror_spawn": 0.04,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_floater"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_floater"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_floater"
+                        }
+                    ]
+                },
+                "enemy_thin_man": {
+                    "normal_spawn": 0.1,
+                    "terror_spawn": 0.04,
+                    "supports": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_thin_man"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_seeker"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_thin_man"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_sectoid"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_thin_man"
+                        }
+                    ]
+                },
+                "enemy_seeker": {
+                    "normal_spawn": 0.09,
+                    "terror_spawn": 0.11,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_seeker"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_seeker"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_seeker"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_drone"
+                        }
+                    ]
+                },
+                "enemy_muton": {
+                    "normal_spawn": 0.13,
+                    "terror_spawn": 0.04,
+                    "supports": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_muton"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_floater"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_muton"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_muton"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_seeker"
+                        }
+                    ]
+                },
+                "enemy_cyberdisc": {
+                    "normal_spawn": 0.09,
+                    "terror_spawn": 0.15,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_cyberdisc"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_seeker"
+                        }
+                    ]
+                },
+                "enemy_mechtoid": {
+                    "normal_spawn": 0.1,
+                    "terror_spawn": 0.08,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_sectoid"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_mechtoid"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ]
+                },
+                "enemy_muton_berserker": {
+                    "normal_spawn": 0.14,
+                    "terror_spawn": 0.09,
+                    "supports": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_muton"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_floater"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_muton_berserker"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_muton_berserker"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_floater"
+                        }
+                    ]
+                },
+                "enemy_sectoid_commander": {
+                    "normal_spawn": 0.04,
+                    "terror_spawn": 0.04,
+                    "supports": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_outsider"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_sectoid"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_sectoid_commander"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_mechtoid"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_outsider"
+                        }
+                    ]
+                },
+                "enemy_group_mechtoid": {
+                    "normal_spawn": 0.04,
+                    "terror_spawn": 0.02,
+                    "supports": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_muton"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_sectoid"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_mechtoid"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_sectoid_commander"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_drone"
+                        }
+                    ]
+                },
+                "enemy_heavy_floater": {
+                    "normal_spawn": 0.14,
+                    "terror_spawn": 0.09,
+                    "supports": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_floater"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_heavy_floater"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_heavy_floater"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_floater"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_chryssalid"
+                        }
+                    ]
+                },
+                "enemy_group_exalt": {
+                    "normal_spawn": 0,
+                    "terror_spawn": 0.03,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_exalt_operative"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_group_exalt"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_group_exalt"
+                        }
+                    ]
+                },
+                "enemy_group_exalt_elite": {
+                    "normal_spawn": 0,
+                    "terror_spawn": 0.07,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_exalt_elite_operative"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_group_exalt_elite"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_group_exalt_elite"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "alien_research": 252,
+            "aliens": {
+                "enemy_sectoid": {
+                    "normal_spawn": 0.07,
+                    "terror_spawn": 0,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_sectoid"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_sectoid"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_drone"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_sectoid"
+                        }
+                    ]
+                },
+                "enemy_drone": {
+                    "normal_spawn": 0.02,
+                    "terror_spawn": 0,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ]
+                },
+                "enemy_chryssalid": {
+                    "normal_spawn": 0,
+                    "terror_spawn": 0.2,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_chryssalid"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_chryssalid"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_chryssalid"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_zombie"
+                        }
+                    ]
+                },
+                "enemy_floater": {
+                    "normal_spawn": 0.05,
+                    "terror_spawn": 0.05,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_floater"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_floater"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_floater"
+                        }
+                    ]
+                },
+                "enemy_thin_man": {
+                    "normal_spawn": 0.09,
+                    "terror_spawn": 0.04,
+                    "supports": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_thin_man"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_seeker"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_thin_man"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_sectoid"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_thin_man"
+                        }
+                    ]
+                },
+                "enemy_seeker": {
+                    "normal_spawn": 0.07,
+                    "terror_spawn": 0.06,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_seeker"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_seeker"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_seeker"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_drone"
+                        }
+                    ]
+                },
+                "enemy_muton": {
+                    "normal_spawn": 0.12,
+                    "terror_spawn": 0.04,
+                    "supports": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_muton"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_floater"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_muton"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_muton"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_seeker"
+                        }
+                    ]
+                },
+                "enemy_cyberdisc": {
+                    "normal_spawn": 0.09,
+                    "terror_spawn": 0.15,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_cyberdisc"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_seeker"
+                        }
+                    ]
+                },
+                "enemy_mechtoid": {
+                    "normal_spawn": 0.11,
+                    "terror_spawn": 0.08,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_sectoid"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_mechtoid"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ]
+                },
+                "enemy_muton_berserker": {
+                    "normal_spawn": 0.07,
+                    "terror_spawn": 0.08,
+                    "supports": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_muton"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_floater"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_muton_berserker"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_muton_berserker"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_floater"
+                        }
+                    ]
+                },
+                "enemy_sectoid_commander": {
+                    "normal_spawn": 0.04,
+                    "terror_spawn": 0.02,
+                    "supports": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_outsider"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_sectoid"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_sectoid_commander"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_mechtoid"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_outsider"
+                        }
+                    ]
+                },
+                "enemy_group_mechtoid": {
+                    "normal_spawn": 0.05,
+                    "terror_spawn": 0.02,
+                    "supports": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_muton"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_sectoid"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_mechtoid"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_sectoid_commander"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_drone"
+                        }
+                    ]
+                },
+                "enemy_heavy_floater": {
+                    "normal_spawn": 0.14,
+                    "terror_spawn": 0.08,
+                    "supports": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_floater"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_heavy_floater"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_heavy_floater"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_floater"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_chryssalid"
+                        }
+                    ]
+                },
+                "enemy_group_exalt": {
+                    "normal_spawn": 0,
+                    "terror_spawn": 0.04,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_exalt_operative"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_group_exalt"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_group_exalt"
+                        }
+                    ]
+                },
+                "enemy_group_exalt_elite": {
+                    "normal_spawn": 0,
+                    "terror_spawn": 0.06,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_exalt_elite_operative"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_group_exalt_elite"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_group_exalt_elite"
+                        }
+                    ]
+                },
+                "enemy_muton_elite": {
+                    "normal_spawn": 0.08,
+                    "terror_spawn": 0.05,
+                    "supports": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_muton"
+                        },
+                        {
+                            "chance": 0.16670000000000001,
+                            "alien": "enemy_muton_elite"
+                        },
+                        {
+                            "chance": 0.16670000000000001,
+                            "alien": "enemy_muton_berserker"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_muton_elite"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.4,
+                            "alien": "enemy_muton_elite"
+                        },
+                        {
+                            "chance": 0.3,
+                            "alien": "enemy_heavy_floater"
+                        },
+                        {
+                            "chance": 0.3,
+                            "alien": "enemy_mechtoid"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "alien_research": 280,
+            "aliens": {
+                "enemy_sectoid": {
+                    "normal_spawn": 0.06,
+                    "terror_spawn": 0,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_sectoid"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_sectoid"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_drone"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_sectoid"
+                        }
+                    ]
+                },
+                "enemy_drone": {
+                    "normal_spawn": 0.03,
+                    "terror_spawn": 0,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ]
+                },
+                "enemy_chryssalid": {
+                    "normal_spawn": 0,
+                    "terror_spawn": 0.19,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_chryssalid"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_chryssalid"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_chryssalid"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_zombie"
+                        }
+                    ]
+                },
+                "enemy_floater": {
+                    "normal_spawn": 0.05,
+                    "terror_spawn": 0.04,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_floater"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_floater"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_floater"
+                        }
+                    ]
+                },
+                "enemy_thin_man": {
+                    "normal_spawn": 0.09,
+                    "terror_spawn": 0.04,
+                    "supports": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_thin_man"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_seeker"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_thin_man"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_sectoid"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_thin_man"
+                        }
+                    ]
+                },
+                "enemy_seeker": {
+                    "normal_spawn": 0.07,
+                    "terror_spawn": 0.06,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_seeker"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_seeker"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_seeker"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_drone"
+                        }
+                    ]
+                },
+                "enemy_muton": {
+                    "normal_spawn": 0.11,
+                    "terror_spawn": 0.04,
+                    "supports": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_muton"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_floater"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_muton"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_muton"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_seeker"
+                        }
+                    ]
+                },
+                "enemy_cyberdisc": {
+                    "normal_spawn": 0.09,
+                    "terror_spawn": 0.14,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_cyberdisc"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_seeker"
+                        }
+                    ]
+                },
+                "enemy_mechtoid": {
+                    "normal_spawn": 0.11,
+                    "terror_spawn": 0.08,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_sectoid"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_mechtoid"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ]
+                },
+                "enemy_muton_berserker": {
+                    "normal_spawn": 0.07,
+                    "terror_spawn": 0.07,
+                    "supports": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_muton"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_floater"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_muton_berserker"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_muton_berserker"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_floater"
+                        }
+                    ]
+                },
+                "enemy_sectoid_commander": {
+                    "normal_spawn": 0.09,
+                    "terror_spawn": 0.04,
+                    "supports": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_outsider"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_sectoid"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_sectoid_commander"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_mechtoid"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_outsider"
+                        }
+                    ]
+                },
+                "enemy_group_mechtoid": {
+                    "normal_spawn": 0.05,
+                    "terror_spawn": 0.03,
+                    "supports": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_muton"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_sectoid"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_mechtoid"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_sectoid_commander"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_drone"
+                        }
+                    ]
+                },
+                "enemy_heavy_floater": {
+                    "normal_spawn": 0.11,
+                    "terror_spawn": 0.08,
+                    "supports": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_floater"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_heavy_floater"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_heavy_floater"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_floater"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_chryssalid"
+                        }
+                    ]
+                },
+                "enemy_group_exalt": {
+                    "normal_spawn": 0,
+                    "terror_spawn": 0.03,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_exalt_operative"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_group_exalt"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_group_exalt"
+                        }
+                    ]
+                },
+                "enemy_group_exalt_elite": {
+                    "normal_spawn": 0,
+                    "terror_spawn": 0.06,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_exalt_elite_operative"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_group_exalt_elite"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_group_exalt_elite"
+                        }
+                    ]
+                },
+                "enemy_muton_elite": {
+                    "normal_spawn": 0.07,
+                    "terror_spawn": 0.04,
+                    "supports": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_muton"
+                        },
+                        {
+                            "chance": 0.16670000000000001,
+                            "alien": "enemy_muton_elite"
+                        },
+                        {
+                            "chance": 0.16670000000000001,
+                            "alien": "enemy_muton_berserker"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_muton_elite"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.4,
+                            "alien": "enemy_muton_elite"
+                        },
+                        {
+                            "chance": 0.3,
+                            "alien": "enemy_heavy_floater"
+                        },
+                        {
+                            "chance": 0.3,
+                            "alien": "enemy_mechtoid"
+                        }
+                    ]
+                },
+                "enemy_sectopod": {
+                    "normal_spawn": 0,
+                    "terror_spawn": 0.06,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_sectopod"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_seeker"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "alien_research": 308,
+            "aliens": {
+                "enemy_sectoid": {
+                    "normal_spawn": 0.06,
+                    "terror_spawn": 0,
+                    "supports": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_sectoid"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_exalt_elite_operative"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_sectoid"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_mechtoid"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_exalt_elite_operative"
+                        }
+                    ]
+                },
+                "enemy_drone": {
+                    "normal_spawn": 0.03,
+                    "terror_spawn": 0,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ]
+                },
+                "enemy_chryssalid": {
+                    "normal_spawn": 0,
+                    "terror_spawn": 0.18,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_chryssalid"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_chryssalid"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_chryssalid"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_zombie"
+                        }
+                    ]
+                },
+                "enemy_floater": {
+                    "normal_spawn": 0.05,
+                    "terror_spawn": 0.04,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_floater"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_floater"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_floater"
+                        }
+                    ]
+                },
+                "enemy_thin_man": {
+                    "normal_spawn": 0.09,
+                    "terror_spawn": 0.04,
+                    "supports": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_thin_man"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_seeker"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_thin_man"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_sectoid"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_thin_man"
+                        }
+                    ]
+                },
+                "enemy_seeker": {
+                    "normal_spawn": 0.07,
+                    "terror_spawn": 0.05,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_seeker"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_seeker"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_seeker"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_drone"
+                        }
+                    ]
+                },
+                "enemy_muton": {
+                    "normal_spawn": 0.11,
+                    "terror_spawn": 0.04,
+                    "supports": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_muton"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_floater"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_muton"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_muton"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_seeker"
+                        }
+                    ]
+                },
+                "enemy_cyberdisc": {
+                    "normal_spawn": 0.09,
+                    "terror_spawn": 0.14,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_cyberdisc"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_seeker"
+                        }
+                    ]
+                },
+                "enemy_mechtoid": {
+                    "normal_spawn": 0.11,
+                    "terror_spawn": 0.07,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_sectoid"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_mechtoid"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ]
+                },
+                "enemy_muton_berserker": {
+                    "normal_spawn": 0.07,
+                    "terror_spawn": 0.08,
+                    "supports": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_muton"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_floater"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_muton_berserker"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_muton_berserker"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_floater"
+                        }
+                    ]
+                },
+                "enemy_sectoid_commander": {
+                    "normal_spawn": 0.09,
+                    "terror_spawn": 0.04,
+                    "supports": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_outsider"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_sectoid"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_sectoid_commander"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_mechtoid"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_outsider"
+                        }
+                    ]
+                },
+                "enemy_group_mechtoid": {
+                    "normal_spawn": 0.05,
+                    "terror_spawn": 0.02,
+                    "supports": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_muton"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_sectoid"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_mechtoid"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_sectoid_commander"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_drone"
+                        }
+                    ]
+                },
+                "enemy_heavy_floater": {
+                    "normal_spawn": 0.11,
+                    "terror_spawn": 0.08,
+                    "supports": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_floater"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_heavy_floater"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_heavy_floater"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_floater"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_chryssalid"
+                        }
+                    ]
+                },
+                "enemy_group_exalt": {
+                    "normal_spawn": 0,
+                    "terror_spawn": 0.03,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_exalt_operative"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_group_exalt"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_group_exalt"
+                        }
+                    ]
+                },
+                "enemy_group_exalt_elite": {
+                    "normal_spawn": 0,
+                    "terror_spawn": 0.06,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_exalt_elite_operative"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_group_exalt_elite"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_group_exalt_elite"
+                        }
+                    ]
+                },
+                "enemy_muton_elite": {
+                    "normal_spawn": 0.07,
+                    "terror_spawn": 0.03,
+                    "supports": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_muton"
+                        },
+                        {
+                            "chance": 0.16670000000000001,
+                            "alien": "enemy_muton_elite"
+                        },
+                        {
+                            "chance": 0.16670000000000001,
+                            "alien": "enemy_muton_berserker"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_muton_elite"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.4,
+                            "alien": "enemy_muton_elite"
+                        },
+                        {
+                            "chance": 0.3,
+                            "alien": "enemy_heavy_floater"
+                        },
+                        {
+                            "chance": 0.3,
+                            "alien": "enemy_mechtoid"
+                        }
+                    ]
+                },
+                "enemy_sectopod": {
+                    "normal_spawn": 0,
+                    "terror_spawn": 0.06,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_sectopod"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_seeker"
+                        }
+                    ]
+                },
+                "enemy_ethereal": {
+                    "normal_spawn": 0,
+                    "terror_spawn": 0.03,
+                    "supports": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_muton_elite"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_heavy_floater"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_ethereal"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_muton_elite"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_mechtoid"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "alien_research": 336,
+            "aliens": {
+                "enemy_sectoid": {
+                    "normal_spawn": 0.06,
+                    "terror_spawn": 0,
+                    "supports": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_sectoid"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_exalt_elite_operative"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_sectoid"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_mechtoid"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_exalt_elite_operative"
+                        }
+                    ]
+                },
+                "enemy_drone": {
+                    "normal_spawn": 0.02,
+                    "terror_spawn": 0,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ]
+                },
+                "enemy_chryssalid": {
+                    "normal_spawn": 0,
+                    "terror_spawn": 0.18,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_chryssalid"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_chryssalid"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_chryssalid"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_zombie"
+                        }
+                    ]
+                },
+                "enemy_floater": {
+                    "normal_spawn": 0.05,
+                    "terror_spawn": 0.04,
+                    "supports": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_floater"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_heavy_floater"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_floater"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_floater"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_heavy_floater"
+                        }
+                    ]
+                },
+                "enemy_thin_man": {
+                    "normal_spawn": 0.08,
+                    "terror_spawn": 0.03,
+                    "supports": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_thin_man"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_seeker"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_thin_man"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_sectoid"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_thin_man"
+                        }
+                    ]
+                },
+                "enemy_seeker": {
+                    "normal_spawn": 0.07,
+                    "terror_spawn": 0.05,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_seeker"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_seeker"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_seeker"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_drone"
+                        }
+                    ]
+                },
+                "enemy_muton": {
+                    "normal_spawn": 0.1,
+                    "terror_spawn": 0.04,
+                    "supports": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_muton"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_floater"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_muton"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_muton"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_seeker"
+                        }
+                    ]
+                },
+                "enemy_cyberdisc": {
+                    "normal_spawn": 0.08,
+                    "terror_spawn": 0.13,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_cyberdisc"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_seeker"
+                        }
+                    ]
+                },
+                "enemy_mechtoid": {
+                    "normal_spawn": 0.11,
+                    "terror_spawn": 0.08,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_sectoid"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_mechtoid"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ]
+                },
+                "enemy_muton_berserker": {
+                    "normal_spawn": 0.06,
+                    "terror_spawn": 0.07,
+                    "supports": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_muton"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_floater"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_muton_berserker"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_muton_berserker"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_floater"
+                        }
+                    ]
+                },
+                "enemy_sectoid_commander": {
+                    "normal_spawn": 0.08,
+                    "terror_spawn": 0.04,
+                    "supports": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_outsider"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_sectoid"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_sectoid_commander"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_mechtoid"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_outsider"
+                        }
+                    ]
+                },
+                "enemy_group_mechtoid": {
+                    "normal_spawn": 0.05,
+                    "terror_spawn": 0.02,
+                    "supports": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_muton"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_sectoid"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_mechtoid"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_sectoid_commander"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_drone"
+                        }
+                    ]
+                },
+                "enemy_heavy_floater": {
+                    "normal_spawn": 0.09,
+                    "terror_spawn": 0.07,
+                    "supports": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_floater"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_heavy_floater"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_heavy_floater"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_floater"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_chryssalid"
+                        }
+                    ]
+                },
+                "enemy_group_exalt": {
+                    "normal_spawn": 0,
+                    "terror_spawn": 0.03,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_exalt_operative"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_group_exalt"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_group_exalt"
+                        }
+                    ]
+                },
+                "enemy_group_exalt_elite": {
+                    "normal_spawn": 0,
+                    "terror_spawn": 0.06,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_exalt_elite_operative"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_group_exalt_elite"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_group_exalt_elite"
+                        }
+                    ]
+                },
+                "enemy_muton_elite": {
+                    "normal_spawn": 0.11,
+                    "terror_spawn": 0.04,
+                    "supports": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_muton"
+                        },
+                        {
+                            "chance": 0.16670000000000001,
+                            "alien": "enemy_muton_elite"
+                        },
+                        {
+                            "chance": 0.16670000000000001,
+                            "alien": "enemy_muton_berserker"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_muton_elite"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.4,
+                            "alien": "enemy_muton_elite"
+                        },
+                        {
+                            "chance": 0.3,
+                            "alien": "enemy_heavy_floater"
+                        },
+                        {
+                            "chance": 0.3,
+                            "alien": "enemy_mechtoid"
+                        }
+                    ]
+                },
+                "enemy_sectopod": {
+                    "normal_spawn": 0,
+                    "terror_spawn": 0.08,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_sectopod"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_seeker"
+                        }
+                    ]
+                },
+                "enemy_ethereal": {
+                    "normal_spawn": 0.04,
+                    "terror_spawn": 0.03,
+                    "supports": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_muton_elite"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_heavy_floater"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_ethereal"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_muton_elite"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_mechtoid"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "alien_research": 364,
+            "aliens": {
+                "enemy_sectoid": {
+                    "normal_spawn": 0.06,
+                    "terror_spawn": 0,
+                    "supports": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_sectoid"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_exalt_elite_operative"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_sectoid"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_mechtoid"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_exalt_elite_operative"
+                        }
+                    ]
+                },
+                "enemy_drone": {
+                    "normal_spawn": 0.02,
+                    "terror_spawn": 0,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ]
+                },
+                "enemy_chryssalid": {
+                    "normal_spawn": 0,
+                    "terror_spawn": 0.17,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_chryssalid"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_chryssalid"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_chryssalid"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_zombie"
+                        }
+                    ]
+                },
+                "enemy_floater": {
+                    "normal_spawn": 0.04,
+                    "terror_spawn": 0.04,
+                    "supports": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_floater"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_heavy_floater"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_floater"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_floater"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_heavy_floater"
+                        }
+                    ]
+                },
+                "enemy_thin_man": {
+                    "normal_spawn": 0.08,
+                    "terror_spawn": 0.04,
+                    "supports": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_thin_man"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_seeker"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_thin_man"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_sectoid"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_thin_man"
+                        }
+                    ]
+                },
+                "enemy_seeker": {
+                    "normal_spawn": 0.06,
+                    "terror_spawn": 0.05,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_seeker"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_seeker"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_seeker"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_drone"
+                        }
+                    ]
+                },
+                "enemy_muton": {
+                    "normal_spawn": 0.1,
+                    "terror_spawn": 0.03,
+                    "supports": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_muton"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_floater"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_muton"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_muton"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_seeker"
+                        }
+                    ]
+                },
+                "enemy_cyberdisc": {
+                    "normal_spawn": 0.08,
+                    "terror_spawn": 0.13,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_cyberdisc"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_seeker"
+                        }
+                    ]
+                },
+                "enemy_mechtoid": {
+                    "normal_spawn": 0.1,
+                    "terror_spawn": 0.07,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_sectoid"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_mechtoid"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ]
+                },
+                "enemy_muton_berserker": {
+                    "normal_spawn": 0.06,
+                    "terror_spawn": 0.07,
+                    "supports": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_muton"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_floater"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_muton_berserker"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_muton_berserker"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_floater"
+                        }
+                    ]
+                },
+                "enemy_sectoid_commander": {
+                    "normal_spawn": 0.08,
+                    "terror_spawn": 0.04,
+                    "supports": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_outsider"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_sectoid"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_sectoid_commander"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_mechtoid"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_outsider"
+                        }
+                    ]
+                },
+                "enemy_group_mechtoid": {
+                    "normal_spawn": 0.06,
+                    "terror_spawn": 0.05,
+                    "supports": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_muton"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_sectoid"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_mechtoid"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_sectoid_commander"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_drone"
+                        }
+                    ]
+                },
+                "enemy_heavy_floater": {
+                    "normal_spawn": 0.09,
+                    "terror_spawn": 0.07,
+                    "supports": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_heavy_floater"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_floater"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_heavy_floater"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_heavy_floater"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_chryssalid"
+                        }
+                    ]
+                },
+                "enemy_group_exalt": {
+                    "normal_spawn": 0,
+                    "terror_spawn": 0.03,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_exalt_operative"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_group_exalt"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_group_exalt"
+                        }
+                    ]
+                },
+                "enemy_group_exalt_elite": {
+                    "normal_spawn": 0,
+                    "terror_spawn": 0.05,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_exalt_elite_operative"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_group_exalt_elite"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_group_exalt_elite"
+                        }
+                    ]
+                },
+                "enemy_muton_elite": {
+                    "normal_spawn": 0.1,
+                    "terror_spawn": 0.04,
+                    "supports": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_muton"
+                        },
+                        {
+                            "chance": 0.16670000000000001,
+                            "alien": "enemy_muton_elite"
+                        },
+                        {
+                            "chance": 0.16670000000000001,
+                            "alien": "enemy_muton_berserker"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_muton_elite"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.4,
+                            "alien": "enemy_muton_elite"
+                        },
+                        {
+                            "chance": 0.3,
+                            "alien": "enemy_heavy_floater"
+                        },
+                        {
+                            "chance": 0.3,
+                            "alien": "enemy_mechtoid"
+                        }
+                    ]
+                },
+                "enemy_sectopod": {
+                    "normal_spawn": 0.03,
+                    "terror_spawn": 0.08,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_sectopod"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_seeker"
+                        }
+                    ]
+                },
+                "enemy_ethereal": {
+                    "normal_spawn": 0.03,
+                    "terror_spawn": 0.03,
+                    "supports": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_muton_elite"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_heavy_floater"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_ethereal"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_muton_elite"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_mechtoid"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "alien_research": 392,
+            "aliens": {
+                "enemy_sectoid": {
+                    "normal_spawn": 0.06,
+                    "terror_spawn": 0,
+                    "supports": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_sectoid"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_exalt_elite_operative"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_sectoid"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_mechtoid"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_exalt_elite_operative"
+                        }
+                    ]
+                },
+                "enemy_drone": {
+                    "normal_spawn": 0.02,
+                    "terror_spawn": 0,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ]
+                },
+                "enemy_chryssalid": {
+                    "normal_spawn": 0,
+                    "terror_spawn": 0.17,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_chryssalid"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_chryssalid"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_chryssalid"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_zombie"
+                        }
+                    ]
+                },
+                "enemy_floater": {
+                    "normal_spawn": 0.04,
+                    "terror_spawn": 0.04,
+                    "supports": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_floater"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_heavy_floater"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_floater"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_floater"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_heavy_floater"
+                        }
+                    ]
+                },
+                "enemy_thin_man": {
+                    "normal_spawn": 0.08,
+                    "terror_spawn": 0.04,
+                    "supports": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_thin_man"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_seeker"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_thin_man"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_sectoid"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_thin_man"
+                        }
+                    ]
+                },
+                "enemy_seeker": {
+                    "normal_spawn": 0.06,
+                    "terror_spawn": 0.05,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_seeker"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_seeker"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_seeker"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_drone"
+                        }
+                    ]
+                },
+                "enemy_muton": {
+                    "normal_spawn": 0.1,
+                    "terror_spawn": 0.03,
+                    "supports": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_muton"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_floater"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_muton"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_muton"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_seeker"
+                        }
+                    ]
+                },
+                "enemy_cyberdisc": {
+                    "normal_spawn": 0.08,
+                    "terror_spawn": 0.13,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_cyberdisc"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_seeker"
+                        }
+                    ]
+                },
+                "enemy_mechtoid": {
+                    "normal_spawn": 0.1,
+                    "terror_spawn": 0.07,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_sectoid"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_mechtoid"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ]
+                },
+                "enemy_muton_berserker": {
+                    "normal_spawn": 0.06,
+                    "terror_spawn": 0.07,
+                    "supports": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_muton"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_floater"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_muton_berserker"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_muton_berserker"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_floater"
+                        }
+                    ]
+                },
+                "enemy_sectoid_commander": {
+                    "normal_spawn": 0.08,
+                    "terror_spawn": 0.04,
+                    "supports": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_outsider"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_sectoid"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_sectoid_commander"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_mechtoid"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_outsider"
+                        }
+                    ]
+                },
+                "enemy_group_mechtoid": {
+                    "normal_spawn": 0.06,
+                    "terror_spawn": 0.05,
+                    "supports": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_muton"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_sectoid"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_mechtoid"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_sectoid_commander"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_drone"
+                        }
+                    ]
+                },
+                "enemy_heavy_floater": {
+                    "normal_spawn": 0.09,
+                    "terror_spawn": 0.07,
+                    "supports": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_heavy_floater"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_floater"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_heavy_floater"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_heavy_floater"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_chryssalid"
+                        }
+                    ]
+                },
+                "enemy_group_exalt": {
+                    "normal_spawn": 0,
+                    "terror_spawn": 0.03,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_exalt_operative"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_group_exalt"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_group_exalt"
+                        }
+                    ]
+                },
+                "enemy_group_exalt_elite": {
+                    "normal_spawn": 0,
+                    "terror_spawn": 0.05,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_exalt_elite_operative"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_group_exalt_elite"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_group_exalt_elite"
+                        }
+                    ]
+                },
+                "enemy_muton_elite": {
+                    "normal_spawn": 0.1,
+                    "terror_spawn": 0.04,
+                    "supports": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_muton_elite"
+                        },
+                        {
+                            "chance": 0.25,
+                            "alien": "enemy_muton"
+                        },
+                        {
+                            "chance": 0.25,
+                            "alien": "enemy_muton_berserker"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_muton_elite"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.4,
+                            "alien": "enemy_muton_elite"
+                        },
+                        {
+                            "chance": 0.3,
+                            "alien": "enemy_heavy_floater"
+                        },
+                        {
+                            "chance": 0.3,
+                            "alien": "enemy_mechtoid"
+                        }
+                    ]
+                },
+                "enemy_sectopod": {
+                    "normal_spawn": 0.03,
+                    "terror_spawn": 0.08,
+                    "supports": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_drone"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_sectopod"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_seeker"
+                        }
+                    ]
+                },
+                "enemy_ethereal": {
+                    "normal_spawn": 0.03,
+                    "terror_spawn": 0.03,
+                    "supports": [
+                        {
+                            "chance": 0.67,
+                            "alien": "enemy_muton_elite"
+                        },
+                        {
+                            "chance": 0.33,
+                            "alien": "enemy_heavy_floater"
+                        }
+                    ],
+                    "adjutant": [
+                        {
+                            "chance": 1,
+                            "alien": "enemy_ethereal"
+                        }
+                    ],
+                    "navigators": [
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_muton_elite"
+                        },
+                        {
+                            "chance": 0.5,
+                            "alien": "enemy_mechtoid"
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+}

--- a/assets/html/templates/custom-elements/enemy-infobox.html
+++ b/assets/html/templates/custom-elements/enemy-infobox.html
@@ -86,6 +86,12 @@
             <div id="enemy-infobox-autopsy" class="enemy-infobox-column-body"></div>
             <div id="enemy-infobox-interrogation" class="enemy-infobox-column-body"></div>
         </div>
+        <div id="enemy-spawn-info" class="enemy-infobox-column-body-two-column-even">
+            <div class="enemy-infobox-column-heading" data-tooltip-text="The list of possible alien types that follows this alien pod if this enemy is the pod leader.">Possible Followers</div>
+            <div class="enemy-infobox-column-heading" data-tooltip-text="The list of possible alien types that would be a pod leader this alien may be spawned as a part of.">May Follow</div>
+            <div id="enemy-spawn-followers" class="enemy-infobox-column-body" style="text-align: center;">Cannot be spawned as pod leader</div>
+            <div id="enemy-spawn-leaders" class="enemy-infobox-column-body" style="text-align: center;">Cannot be spawned as pod follower</div>
+        </div>
     </div>
 </template>
 

--- a/assets/html/templates/pages/enemy-display-page.html
+++ b/assets/html/templates/pages/enemy-display-page.html
@@ -138,6 +138,18 @@
                 <div id="enemy-pit-leader-upgrades-not-available" class="hidden-collapse">
                     There are no Leaders available at this level of research.
                 </div>
+
+                <h4>Followers</h4>
+                <div id="enemy-pit-followers-info">
+                    <p>These are the possible alien pod followers if this alien is rolled as a pod leader.</p>
+                    <p>The followers types may be generic supports, navigators, and adjutant.</p>
+                    <p>The 4th to 8th aliens in a pod each have a 10% chance to be an <i>Adjutant</i>, with a maximum number of one Adjutant per pod.</p>
+                    <p>The 2nd to 8th aliens in a pod each have a 30% chance to be a <i>Navigator</i>, if it is not already rolled as an Adjutant with a maximum number of two Navigators per pod.</p>
+                    <div id="enemy-pit-followers-info-container"></div>
+                </div>
+                <div id="enemy-pit-followers-not-available" class="hidden-collapse">
+                    This alien type cannot be a pod leader at this level of research.
+                </div>
             </div>
         </div>
     </div>

--- a/assets/js/custom-elements/enemy-infobox.js
+++ b/assets/js/custom-elements/enemy-infobox.js
@@ -395,13 +395,20 @@ class EnemyInfobox extends HTMLElement {
         unitTypesContainer.textContent = types.join(", ");
     }
 
-    _createFollowerLeader(alienName) {
+    _createFollowerLeader(alienName, terror_chance, normal_chance) {
         const div = document.createElement("div");
         div.setAttribute("data-page-on-click", "enemy-display-page");
         div.setAttribute("data-pagearg-enemy-id", alienName);
         const alienData = DataHelper.enemies[alienName];
         if (alienData) {
-            Utils.appendElement(div, "div", alienData.name, { attributes: { "data-page-on-click": "enemy-display-page", "data-pagearg-enemy-id": alienName, "style": "cursor: pointer;" } });
+            const alienNameData = [alienData.name];
+            if (terror_chance) {
+                alienNameData.push(`T:${(terror_chance * 100).toFixed(0)}%`);
+            }
+            if (normal_chance) {
+                alienNameData.push(`N:${(normal_chance * 100).toFixed(0)}%`);
+            }
+            Utils.appendElement(div, "div", alienNameData.join(" "), { attributes: { "data-page-on-click": "enemy-display-page", "data-pagearg-enemy-id": alienName, "style": "cursor: pointer;" } });
         }
 
         return div;
@@ -413,18 +420,24 @@ class EnemyInfobox extends HTMLElement {
 
         const info = DataHelper.deploymentPossibleFollowerLeader(enemyName, this.alienResearch || null);
 
-        if (info.leaders.length) {
-            leadersSelector.textContent = "";
+        if (Object.keys(info.leaders).length) {
+            leadersSelector.innerHTML = "";
             for (const alienName in info.leaders) {
-                leadersSelector.appendChild(this._createFollowerLeader(info.leaders[alienName]))
+                leadersSelector.appendChild(this._createFollowerLeader(alienName, info.leaders[alienName].terror, info.leaders[alienName].normal))
             }
+        }
+        else {
+            leadersSelector.innerHTML = "Cannot be spawned as pod leader";
         }
 
         if (info.followers.length) {
-            followerSelector.textContent = "";
+            followerSelector.innerHTML = "";
             for (const alienName in info.followers) {
                 followerSelector.appendChild(this._createFollowerLeader(info.followers[alienName]))
             }
+        }
+        else {
+            followerSelector.innerHTML = "Cannot be spawned as pod follower";
         }
     }
 

--- a/assets/js/custom-elements/enemy-infobox.js
+++ b/assets/js/custom-elements/enemy-infobox.js
@@ -395,6 +395,39 @@ class EnemyInfobox extends HTMLElement {
         unitTypesContainer.textContent = types.join(", ");
     }
 
+    _createFollowerLeader(alienName) {
+        const div = document.createElement("div");
+        div.setAttribute("data-page-on-click", "enemy-display-page");
+        div.setAttribute("data-pagearg-enemy-id", alienName);
+        const alienData = DataHelper.enemies[alienName];
+        if (alienData) {
+            Utils.appendElement(div, "div", alienData.name, { attributes: { "data-page-on-click": "enemy-display-page", "data-pagearg-enemy-id": alienName, "style": "cursor: pointer;" } });
+        }
+
+        return div;
+    }
+
+    _populateEncounters(template, enemyName) {
+        const leadersSelector = template.querySelector("#enemy-spawn-leaders");
+        const followerSelector = template.querySelector("#enemy-spawn-followers");
+
+        const info = DataHelper.deploymentPossibleFollowerLeader(enemyName, this.alienResearch || null);
+
+        if (info.leaders.length) {
+            leadersSelector.textContent = "";
+            for (const alienName in info.leaders) {
+                leadersSelector.appendChild(this._createFollowerLeader(info.leaders[alienName]))
+            }
+        }
+
+        if (info.followers.length) {
+            followerSelector.textContent = "";
+            for (const alienName in info.followers) {
+                followerSelector.appendChild(this._createFollowerLeader(info.followers[alienName]))
+            }
+        }
+    }
+
     _recreateContents() {
         if (!this.enemyId) {
             this.innerHTML = "";
@@ -419,6 +452,7 @@ class EnemyInfobox extends HTMLElement {
             this._populateStats(template, enemyStats);
             this._populateSubtitle(template, this.#enemy);
             this._populateUnitTypes(template, this.#enemy);
+            this._populateEncounters(template, this.enemyId);
 
             this._showHideMiniFields(template);
 
@@ -434,7 +468,7 @@ class EnemyInfobox extends HTMLElement {
             template.querySelector("#kill-rewards-heading"),
             template.querySelector("#kill-rewards"),
             template.querySelector("#capture-rewards-heading"),
-            template.querySelector("#capture-rewards")
+            template.querySelector("#capture-rewards"),
         ];
 
         const hideInTiny = [
@@ -444,7 +478,8 @@ class EnemyInfobox extends HTMLElement {
             template.querySelector("#enemy-infobox-perks-container"),
             template.querySelector("#enemy-infobox-perks-heading"),
             template.querySelector(".enemy-infobox-stats-container"),
-            template.querySelector("#enemy-infobox-stats-heading")
+            template.querySelector("#enemy-infobox-stats-heading"),
+            template.querySelector("#enemy-spawn-info"),
         ]
 
         for (const elem of hideInMini) {

--- a/assets/js/data-helper.js
+++ b/assets/js/data-helper.js
@@ -663,13 +663,37 @@ function deploymentFollowers(deployment) {
 
 function deploymentPossibleFollowerLeader(alienName, alienResearch) {
     const nameMatches = encounterMatches(alienName);
+    const hasResearch = alienResearch != null
     let deployments = deploymentsData.deployments;
-    if (alienResearch != null) {
+    if (hasResearch) {
         deployments = [deploymentsForAlienResearch(alienResearch)];
     }
     const followers = deployments.flatMap((m) => nameMatches.flatMap((n) => deploymentFollowers(m.aliens[n])));
     const leaders = deployments.map((m) => Object.entries(m.aliens).filter(([_, d]) => nameMatches.some((n) => deploymentFollowers(d).includes(n))).map(([leader, _]) => leader)).flat(Infinity);
-    return {leaders: expandEncounterGroups(leaders), followers: expandEncounterGroups(followers)};
+    
+    const leaders_obj = {};
+    expandEncounterGroups(leaders).forEach((leader) => {
+        if (hasResearch) {
+            const leaderMatches = {[leader]: 1};
+            Object.entries(deploymentsData.groups).forEach(([n, v]) => {
+                if (v.includes(alienName)) {
+                    leaderMatches[n] = 1 / v.length;
+                }
+            });
+            leaders_obj[leader] = deployments.flatMap((m) => Object.entries(leaderMatches).map(([n, v]) => ({normal: (m.aliens[n]?.normal_spawn ?? 0) * leaderMatches[n], terror: (m.aliens[n]?.terror_spawn ?? 0) * leaderMatches[n]}))).reduce((p, c) => ({normal: p.normal + c.normal, terror: p.terror + c.terror}), {normal: 0, terror: 0});
+        } else {
+            leaders_obj[leader] = {};
+        }
+    });
+    if (hasResearch) {
+        const {normal, terror} = Object.values(leaders_obj).reduce((p, c) => ({normal: p.normal + c.normal, terror: p.terror + c.terror }), {normal: 0, terror: 0});
+        Object.keys(leaders_obj).forEach((k) => {
+            leaders_obj[k].normal = leaders_obj[k].normal / normal;
+            leaders_obj[k].terror = leaders_obj[k].terror / terror;
+        });
+    }
+    
+    return {leaders: leaders_obj, followers: expandEncounterGroups(followers)};
 }
 
 function typeOf(dataObject) {

--- a/assets/js/data-helper.js
+++ b/assets/js/data-helper.js
@@ -4,6 +4,7 @@ import * as Utils from "./utils.js";
 const baseFacilityData = await fetch("assets/data/base-facilities.json").then(response => response.json());
 const councilRequestData = await fetch("assets/data/council-requests.json").then(response => response.json());
 const enemyData = await fetch("assets/data/enemies.json").then(response => response.json());
+const deploymentsData = await fetch("assets/data/enemy_deployments.json").then(response => response.json());
 const foundryProjectData = await fetch("assets/data/foundry-projects.json").then(response => response.json());
 const geneModData = await fetch("assets/data/gene-mods.json").then(response => response.json());
 const itemData = await fetch("assets/data/items.json").then(response => response.json());
@@ -593,6 +594,84 @@ function getResearchCreditSource(creditType) {
     return null;
 }
 
+function expandDeployment(deploymentList) {
+    if (!deploymentList) {
+        return [];
+    }
+
+    return deploymentList.flatMap((f) => {
+        const groupMatch = deploymentsData.groups[f.alien];
+        if (!groupMatch) {
+            return f;
+        }
+
+        return groupMatch.map((a) => {
+            return {
+                "chance": f.chance / groupMatch.length,
+                "alien": a
+            }
+        });
+    });
+}
+
+function expandEncounterEntry(encounterEntry) {
+    encounterEntry.supports = expandDeployment(encounterEntry.supports);
+    encounterEntry.adjutant = expandDeployment(encounterEntry.adjutant);
+    encounterEntry.navigators = expandDeployment(encounterEntry.navigators);
+}
+
+function deploymentsForAlienResearch(alienResearch) {
+    const arInt = parseInt(alienResearch);
+    if (arInt == NaN) {
+        return [];
+    }
+
+    const deployments = deploymentsData.deployments.filter((d) => d.alien_research < arInt).reduce((p, c) => {
+        if (c.alien_research > p.alien_research) {
+            return c;
+        }
+        return p;
+    }) || [];
+
+    if (deployments.aliens) {
+        Object.keys(deployments.aliens).forEach((a) => {
+            expandEncounterEntry(deployments.aliens[a]);
+        })
+    }
+
+    return deployments;
+}
+
+function uniqNotNull(a) {
+    return a.filter((v, i) => v && a.indexOf(v) === i);
+}
+
+function expandEncounterGroups(nameList) {
+    return uniqNotNull(nameList.flatMap((v) => deploymentsData.groups[v] || v));
+}
+
+function encounterMatches(alienName) {
+    return [alienName, ...Object.entries(deploymentsData.groups).filter(([_, v]) => v.includes(alienName)).map(([n, _]) => n)];
+}
+
+function deploymentFollowers(deployment) {
+    if (!deployment) {
+        return [];
+    }
+    return uniqNotNull([deployment.supports, deployment.adjutant, deployment.navigators].flat().map((s) => s.alien));
+}
+
+function deploymentPossibleFollowerLeader(alienName, alienResearch) {
+    const nameMatches = encounterMatches(alienName);
+    let deployments = deploymentsData.deployments;
+    if (alienResearch != null) {
+        deployments = [deploymentsForAlienResearch(alienResearch)];
+    }
+    const followers = deployments.flatMap((m) => nameMatches.flatMap((n) => deploymentFollowers(m.aliens[n])));
+    const leaders = deployments.map((m) => Object.entries(m.aliens).filter(([_, d]) => nameMatches.some((n) => deploymentFollowers(d).includes(n))).map(([leader, _]) => leader)).flat(Infinity);
+    return {leaders: expandEncounterGroups(leaders), followers: expandEncounterGroups(followers)};
+}
+
 function typeOf(dataObject) {
     const id = typeof(dataObject) === "string" ? dataObject : dataObject.id;
 
@@ -626,6 +705,9 @@ export {
     councilRequests,
     countries,
     dataObjectById,
+    deploymentsData,
+    deploymentsForAlienResearch,
+    deploymentPossibleFollowerLeader,
     enemies,
     enemyDamageRanges,
     foundryProjects,

--- a/assets/js/page-controllers/enemy-display-page.js
+++ b/assets/js/page-controllers/enemy-display-page.js
@@ -435,6 +435,82 @@ class EnemyDisplayPage extends AppPage {
         }
     }
 
+    _generateFollowersGrid(container, encounterList, heading) {
+        if (!encounterList) {
+            return;
+        }
+        const header = document.createElement("h4");
+        header.textContent = heading;
+        container.appendChild(header);
+
+        if (encounterList.normal_spawn) {
+            const normal_spawn_text = document.createElement("p");
+            normal_spawn_text.textContent = `Chance to Spawn (Normal): ${(encounterList.normal_spawn * 100).toFixed(2)}%`;
+            container.appendChild(normal_spawn_text);
+        }
+        if (encounterList.terror_spawn) {
+            const terror_spawn_text = document.createElement("p");
+            terror_spawn_text.textContent = `Chance to Spawn (Terror): ${(encounterList.terror_spawn * 100).toFixed(2)}%`;
+            container.appendChild(terror_spawn_text);
+        }
+
+        const columns = [
+            {
+                key: "supports",
+                header: "Generic Supports",
+                size: "100px"
+            },
+            {
+                key: "adjutant",
+                header: "Adjutant",
+                size: "100px"
+            },
+            {
+                key: "navigators",
+                header: "Navigators",
+                size: "100px"
+            },
+        ];
+
+        
+        // Get values for the header row and column sizes
+        const headers = [], sizes = [];
+        for (const column of columns) {
+            headers.push(column.header);
+            sizes.push(column.size || "50px");
+        }
+
+        let idx = 0;
+        const values = [];
+        while (true) {
+            const row = [];
+            Object.values(columns).forEach((c) => {
+                if (encounterList[c.key] && encounterList[c.key].length > idx) {
+                    let n = encounterList[c.key][idx].alien;
+                    const alienEntry = DataHelper.enemies[n];
+                    if (alienEntry && alienEntry.name) {
+                        n = alienEntry.name;
+                    }
+                    row.push(`${n} (${(encounterList[c.key][idx].chance * 100).toFixed(2)}%)`);
+                } else {
+                    row.push("");
+                }
+            });
+
+            if (row.every((r) => r.length == 0)) {
+                break;
+            }
+
+            row.forEach((r) => values.push(r));
+            idx += 1;
+        }
+
+        const grid = Utils.createGrid(headers, sizes, values);
+        grid.classList.add("enemy-upgrades-container");
+
+        container.appendChild(grid);
+    }
+
     _populateGrids(container) {
         const enemy = DataHelper.enemies[this.#enemyId];
 
@@ -491,6 +567,29 @@ class EnemyDisplayPage extends AppPage {
         else {
             container.querySelector("#enemy-pit-leader-upgrades-not-available").classList.remove("hidden-collapse");
             container.querySelector("#enemy-pit-leader-upgrades-info").classList.add("hidden-collapse");
+        }
+
+        const deployments = DataHelper.deploymentsForAlienResearch(EnemyDisplayPage.currentResearch);
+        const deploymentGroups = DataHelper.deploymentsData.groups;
+        const groupDeploymentNames = Object.keys(deploymentGroups).filter((g) => deploymentGroups[g].includes(enemy.id));
+
+        const mainEncounter = deployments.aliens[enemy.id];
+        const additionalEncounters = groupDeploymentNames.map((g) => deployments.aliens[g]).filter((g) => g) || [];
+
+        if (mainEncounter || additionalEncounters.length) {
+            const containerSelector = "#enemy-pit-followers-info-container";
+            const gridContainer = container.querySelector(containerSelector);
+
+            this._generateFollowersGrid(gridContainer, mainEncounter, enemy.name);
+            for (let idx = 0; idx < additionalEncounters.length; ++idx) {
+                this._generateFollowersGrid(gridContainer, additionalEncounters[idx], `${enemy.name} (Variant Pod ${idx + 1})`);
+            }
+            container.querySelector("#enemy-pit-followers-not-available").classList.add("hidden-collapse");
+            container.querySelector("#enemy-pit-followers-info").classList.remove("hidden-collapse");
+        } 
+        else {
+            container.querySelector("#enemy-pit-followers-not-available").classList.remove("hidden-collapse");
+            container.querySelector("#enemy-pit-followers-info").classList.add("hidden-collapse");
         }
     }
 

--- a/assets/js/page-controllers/enemy-display-page.js
+++ b/assets/js/page-controllers/enemy-display-page.js
@@ -579,6 +579,7 @@ class EnemyDisplayPage extends AppPage {
         if (mainEncounter || additionalEncounters.length) {
             const containerSelector = "#enemy-pit-followers-info-container";
             const gridContainer = container.querySelector(containerSelector);
+            gridContainer.innerHTML = "";
 
             this._generateFollowersGrid(gridContainer, mainEncounter, enemy.name);
             for (let idx = 0; idx < additionalEncounters.length; ++idx) {


### PR DESCRIPTION
Added information for whether an alien may be a follower or leader of a pod by listing what they can be a follower of or their followers if they are the leader. Also added a table of followers and chances to roll in their point-in-time page.

Information extracted from the table in https://www.ufopaedia.org/index.php?title=Alien_Deployment_(Long_War)#Pod_Composition_Tables